### PR TITLE
Ребаланс/Фикс #2

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/anaconda.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/anaconda.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/22/2025 00:03:22
+  time: 06/29/2025 02:04:22
   entityCount: 860
 maps: []
 grids:
@@ -86,6 +86,7 @@ entities:
       id: Anaconda
     - type: OccluderTree
     - type: Shuttle
+      dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -624,7 +625,7 @@ entities:
     - type: RadiationGridResistance
 - proto: AirAlarm
   entities:
-  - uid: 716
+  - uid: 2
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -632,23 +633,23 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 712
-      - 713
-      - 710
-      - 711
-      - 408
-      - 413
-  - uid: 719
+      - 404
+      - 405
+      - 402
+      - 403
+      - 504
+      - 511
+  - uid: 3
     components:
     - type: Transform
       pos: -6.5,-26.5
       parent: 1
     - type: DeviceList
       devices:
-      - 711
-      - 482
-      - 483
-  - uid: 720
+      - 403
+      - 509
+      - 516
+  - uid: 4
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -656,10 +657,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 710
-      - 373
-      - 374
-  - uid: 724
+      - 402
+      - 503
+      - 510
+  - uid: 5
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -667,11 +668,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 712
-      - 714
-      - 476
-      - 478
-  - uid: 725
+      - 404
+      - 406
+      - 507
+      - 515
+  - uid: 6
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -679,21 +680,21 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 713
-      - 715
-      - 475
-      - 468
-  - uid: 726
+      - 405
+      - 407
+      - 506
+      - 512
+  - uid: 7
     components:
     - type: Transform
       pos: 4.5,-21.5
       parent: 1
     - type: DeviceList
       devices:
-      - 715
-      - 474
-      - 473
-  - uid: 729
+      - 407
+      - 505
+      - 514
+  - uid: 8
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -701,12 +702,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 714
-      - 477
-      - 472
-- proto: AirlockExternalGlassRogueLocked
+      - 406
+      - 508
+      - 513
+- proto: AirlockExternalGlassPirateLocked
   entities:
-  - uid: 124
+  - uid: 9
     components:
     - type: Transform
       pos: 2.5,-13.5
@@ -715,9 +716,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        134:
-        - DoorStatus: DoorBolt
-  - uid: 134
+        10:
+        - - DoorStatus
+          - DoorBolt
+  - uid: 10
     components:
     - type: Transform
       pos: 3.5,-10.5
@@ -726,9 +728,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        124:
-        - DoorStatus: DoorBolt
-  - uid: 264
+        9:
+        - - DoorStatus
+          - DoorBolt
+  - uid: 11
     components:
     - type: Transform
       pos: -3.5,-13.5
@@ -737,9 +740,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        265:
-        - DoorStatus: DoorBolt
-  - uid: 265
+        12:
+        - - DoorStatus
+          - DoorBolt
+  - uid: 12
     components:
     - type: Transform
       pos: -4.5,-10.5
@@ -748,95 +752,96 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        264:
-        - DoorStatus: DoorBolt
-  - uid: 699
+        11:
+        - - DoorStatus
+          - DoorBolt
+  - uid: 13
     components:
     - type: Transform
       pos: 0.5,-36.5
       parent: 1
-  - uid: 700
+  - uid: 14
     components:
     - type: Transform
       pos: -0.5,-36.5
       parent: 1
-  - uid: 701
+  - uid: 15
     components:
     - type: Transform
       pos: -1.5,-36.5
       parent: 1
-- proto: AirlockHatchRogueLocked
+- proto: AirlockGlassShuttleSyndicate
   entities:
-  - uid: 290
-    components:
-    - type: Transform
-      pos: -4.5,-18.5
-      parent: 1
-  - uid: 291
-    components:
-    - type: Transform
-      pos: -4.5,-20.5
-      parent: 1
-  - uid: 292
-    components:
-    - type: Transform
-      pos: 3.5,-18.5
-      parent: 1
-  - uid: 293
-    components:
-    - type: Transform
-      pos: 3.5,-20.5
-      parent: 1
-  - uid: 306
-    components:
-    - type: Transform
-      pos: 3.5,-24.5
-      parent: 1
-  - uid: 314
-    components:
-    - type: Transform
-      pos: 2.5,-29.5
-      parent: 1
-  - uid: 315
-    components:
-    - type: Transform
-      pos: 1.5,-27.5
-      parent: 1
-  - uid: 316
-    components:
-    - type: Transform
-      pos: -2.5,-27.5
-      parent: 1
-  - uid: 327
-    components:
-    - type: Transform
-      pos: -4.5,-24.5
-      parent: 1
-  - uid: 343
-    components:
-    - type: Transform
-      pos: -3.5,-29.5
-      parent: 1
-- proto: AirlockShuttleSyndicateRogueLocked
-  entities:
-  - uid: 702
-    components:
-    - type: Transform
-      pos: 0.5,-39.5
-      parent: 1
-  - uid: 703
+  - uid: 26
     components:
     - type: Transform
       pos: -0.5,-39.5
       parent: 1
-  - uid: 704
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 0.5,-39.5
+      parent: 1
+  - uid: 28
     components:
     - type: Transform
       pos: -1.5,-39.5
       parent: 1
+- proto: AirlockHatchPirateLocked
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -4.5,-18.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -4.5,-20.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 3.5,-18.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 3.5,-20.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 3.5,-24.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 2.5,-29.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 1.5,-27.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -2.5,-27.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -4.5,-24.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -3.5,-29.5
+      parent: 1
 - proto: AmeController
   entities:
-  - uid: 355
+  - uid: 29
     components:
     - type: Transform
       pos: 3.5,-27.5
@@ -848,38 +853,38 @@ entities:
         fuelSlot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 356
+          ent: 30
 - proto: AmeJar
   entities:
-  - uid: 356
+  - uid: 30
     components:
     - type: Transform
-      parent: 355
+      parent: 29
     - type: Physics
       canCollide: False
 - proto: AmeShielding
   entities:
-  - uid: 346
+  - uid: 31
     components:
     - type: Transform
       pos: 6.5,-26.5
       parent: 1
-  - uid: 347
+  - uid: 32
     components:
     - type: Transform
       pos: 6.5,-27.5
       parent: 1
-  - uid: 348
+  - uid: 33
     components:
     - type: Transform
       pos: 6.5,-28.5
       parent: 1
-  - uid: 349
+  - uid: 34
     components:
     - type: Transform
       pos: 5.5,-26.5
       parent: 1
-  - uid: 350
+  - uid: 35
     components:
     - type: Transform
       pos: 5.5,-27.5
@@ -887,57 +892,57 @@ entities:
     - type: PointLight
       radius: 2
       enabled: True
-  - uid: 351
+  - uid: 36
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 1
-  - uid: 352
+  - uid: 37
     components:
     - type: Transform
       pos: 4.5,-26.5
       parent: 1
-  - uid: 353
+  - uid: 38
     components:
     - type: Transform
       pos: 4.5,-27.5
       parent: 1
-  - uid: 354
+  - uid: 39
     components:
     - type: Transform
       pos: 4.5,-28.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 728
+  - uid: 40
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 705
+  - uid: 41
     components:
     - type: Transform
       pos: 0.5,-39.5
       parent: 1
-  - uid: 706
+  - uid: 42
     components:
     - type: Transform
       pos: -0.5,-39.5
       parent: 1
-  - uid: 707
+  - uid: 43
     components:
     - type: Transform
       pos: -1.5,-39.5
       parent: 1
-  - uid: 708
+  - uid: 44
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-10.5
       parent: 1
-  - uid: 709
+  - uid: 45
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -945,1722 +950,1722 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 627
+  - uid: 46
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
-  - uid: 655
+  - uid: 47
     components:
     - type: Transform
       pos: 9.5,-29.5
       parent: 1
-  - uid: 657
+  - uid: 48
     components:
     - type: Transform
       pos: 9.5,-28.5
       parent: 1
-  - uid: 731
+  - uid: 49
     components:
     - type: Transform
       pos: 9.5,-30.5
       parent: 1
-  - uid: 732
+  - uid: 50
     components:
     - type: Transform
       pos: 8.5,-28.5
       parent: 1
-  - uid: 733
+  - uid: 51
     components:
     - type: Transform
       pos: 8.5,-29.5
       parent: 1
-  - uid: 734
+  - uid: 52
     components:
     - type: Transform
       pos: 8.5,-30.5
       parent: 1
-  - uid: 735
+  - uid: 53
     components:
     - type: Transform
       pos: 8.5,-33.5
       parent: 1
-  - uid: 736
+  - uid: 54
     components:
     - type: Transform
       pos: 7.5,-36.5
       parent: 1
-  - uid: 737
+  - uid: 55
     components:
     - type: Transform
       pos: 6.5,-35.5
       parent: 1
-  - uid: 738
+  - uid: 56
     components:
     - type: Transform
       pos: 6.5,-34.5
       parent: 1
-  - uid: 739
+  - uid: 57
     components:
     - type: Transform
       pos: 5.5,-34.5
       parent: 1
-  - uid: 740
+  - uid: 58
     components:
     - type: Transform
       pos: 5.5,-33.5
       parent: 1
-  - uid: 741
+  - uid: 59
     components:
     - type: Transform
       pos: 4.5,-33.5
       parent: 1
-  - uid: 742
+  - uid: 60
     components:
     - type: Transform
       pos: 4.5,-32.5
       parent: 1
-  - uid: 743
+  - uid: 61
     components:
     - type: Transform
       pos: 3.5,-35.5
       parent: 1
-  - uid: 744
+  - uid: 62
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 1
-  - uid: 745
+  - uid: 63
     components:
     - type: Transform
       pos: -3.5,-37.5
       parent: 1
-  - uid: 746
+  - uid: 64
     components:
     - type: Transform
       pos: -4.5,-35.5
       parent: 1
-  - uid: 747
+  - uid: 65
     components:
     - type: Transform
       pos: -5.5,-32.5
       parent: 1
-  - uid: 748
+  - uid: 66
     components:
     - type: Transform
       pos: -5.5,-33.5
       parent: 1
-  - uid: 749
+  - uid: 67
     components:
     - type: Transform
       pos: -6.5,-33.5
       parent: 1
-  - uid: 750
+  - uid: 68
     components:
     - type: Transform
       pos: -6.5,-34.5
       parent: 1
-  - uid: 751
+  - uid: 69
     components:
     - type: Transform
       pos: -7.5,-34.5
       parent: 1
-  - uid: 752
+  - uid: 70
     components:
     - type: Transform
       pos: -7.5,-35.5
       parent: 1
-  - uid: 753
+  - uid: 71
     components:
     - type: Transform
       pos: -8.5,-36.5
       parent: 1
-  - uid: 754
+  - uid: 72
     components:
     - type: Transform
       pos: -9.5,-33.5
       parent: 1
-  - uid: 755
+  - uid: 73
     components:
     - type: Transform
       pos: -9.5,-28.5
       parent: 1
-  - uid: 756
+  - uid: 74
     components:
     - type: Transform
       pos: -9.5,-29.5
       parent: 1
-  - uid: 757
+  - uid: 75
     components:
     - type: Transform
       pos: -9.5,-30.5
       parent: 1
-  - uid: 758
+  - uid: 76
     components:
     - type: Transform
       pos: -10.5,-28.5
       parent: 1
-  - uid: 759
+  - uid: 77
     components:
     - type: Transform
       pos: -10.5,-29.5
       parent: 1
-  - uid: 760
+  - uid: 78
     components:
     - type: Transform
       pos: -10.5,-30.5
       parent: 1
-  - uid: 761
+  - uid: 79
     components:
     - type: Transform
       pos: -9.5,-26.5
       parent: 1
-  - uid: 762
+  - uid: 80
     components:
     - type: Transform
       pos: -8.5,-23.5
       parent: 1
-  - uid: 763
+  - uid: 81
     components:
     - type: Transform
       pos: -7.5,-19.5
       parent: 1
-  - uid: 764
+  - uid: 82
     components:
     - type: Transform
       pos: -7.5,-20.5
       parent: 1
-  - uid: 765
+  - uid: 83
     components:
     - type: Transform
       pos: 6.5,-19.5
       parent: 1
-  - uid: 766
+  - uid: 84
     components:
     - type: Transform
       pos: 6.5,-20.5
       parent: 1
-  - uid: 767
+  - uid: 85
     components:
     - type: Transform
       pos: 7.5,-23.5
       parent: 1
-  - uid: 768
+  - uid: 86
     components:
     - type: Transform
       pos: 8.5,-26.5
       parent: 1
-  - uid: 769
+  - uid: 87
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
-  - uid: 770
+  - uid: 88
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 1
-  - uid: 771
+  - uid: 89
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
-  - uid: 772
+  - uid: 90
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 773
+  - uid: 91
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 774
+  - uid: 92
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 775
+  - uid: 93
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 776
+  - uid: 94
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 777
+  - uid: 95
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
-  - uid: 778
+  - uid: 96
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 779
+  - uid: 97
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 780
+  - uid: 98
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 781
+  - uid: 99
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 782
+  - uid: 100
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 783
+  - uid: 101
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 784
+  - uid: 102
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 785
+  - uid: 103
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 786
+  - uid: 104
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 787
+  - uid: 105
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 788
+  - uid: 106
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 789
+  - uid: 107
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 790
+  - uid: 108
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 791
+  - uid: 109
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 792
+  - uid: 110
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 793
+  - uid: 111
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 794
+  - uid: 112
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 795
+  - uid: 113
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 796
+  - uid: 114
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 797
+  - uid: 115
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 1
-  - uid: 798
+  - uid: 116
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 1
-  - uid: 799
+  - uid: 117
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 1
-  - uid: 800
+  - uid: 118
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 801
+  - uid: 119
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
-  - uid: 802
+  - uid: 120
     components:
     - type: Transform
       pos: -1.5,-17.5
       parent: 1
-  - uid: 803
+  - uid: 121
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 1
-  - uid: 804
+  - uid: 122
     components:
     - type: Transform
       pos: -1.5,-19.5
       parent: 1
-  - uid: 805
+  - uid: 123
     components:
     - type: Transform
       pos: -1.5,-20.5
       parent: 1
-  - uid: 806
+  - uid: 124
     components:
     - type: Transform
       pos: -1.5,-21.5
       parent: 1
-  - uid: 807
+  - uid: 125
     components:
     - type: Transform
       pos: -1.5,-22.5
       parent: 1
-  - uid: 808
+  - uid: 126
     components:
     - type: Transform
       pos: -1.5,-23.5
       parent: 1
-  - uid: 809
+  - uid: 127
     components:
     - type: Transform
       pos: 0.5,-23.5
       parent: 1
-  - uid: 810
+  - uid: 128
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 1
-  - uid: 811
+  - uid: 129
     components:
     - type: Transform
       pos: 0.5,-21.5
       parent: 1
-  - uid: 812
+  - uid: 130
     components:
     - type: Transform
       pos: 0.5,-20.5
       parent: 1
-  - uid: 813
+  - uid: 131
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
-  - uid: 814
+  - uid: 132
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
-  - uid: 815
+  - uid: 133
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-  - uid: 816
+  - uid: 134
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
-  - uid: 817
+  - uid: 135
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 818
+  - uid: 136
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
-  - uid: 819
+  - uid: 137
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 820
+  - uid: 138
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 821
+  - uid: 139
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 822
+  - uid: 140
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 823
+  - uid: 141
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 824
+  - uid: 142
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 825
+  - uid: 143
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 826
+  - uid: 144
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 827
+  - uid: 145
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 828
+  - uid: 146
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 829
+  - uid: 147
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 830
+  - uid: 148
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 831
+  - uid: 149
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 832
+  - uid: 150
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 833
+  - uid: 151
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 834
+  - uid: 152
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 835
+  - uid: 153
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 836
+  - uid: 154
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 837
+  - uid: 155
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 838
+  - uid: 156
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 1
-  - uid: 839
+  - uid: 157
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
-  - uid: 840
+  - uid: 158
     components:
     - type: Transform
       pos: -0.5,-25.5
       parent: 1
 - proto: Autolathe
   entities:
-  - uid: 658
+  - uid: 159
     components:
     - type: Transform
       pos: -7.5,-27.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 644
+  - uid: 160
     components:
     - type: Transform
       pos: -4.5,-30.5
       parent: 1
 - proto: BedsheetBlack
   entities:
-  - uid: 645
+  - uid: 161
     components:
     - type: Transform
       pos: -4.5,-30.5
       parent: 1
 - proto: BorgCharger
   entities:
-  - uid: 622
+  - uid: 162
     components:
     - type: Transform
       pos: -0.5,-27.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 506
+  - uid: 163
     components:
     - type: Transform
       pos: 6.5,-29.5
       parent: 1
-  - uid: 507
+  - uid: 164
     components:
     - type: Transform
       pos: 5.5,-29.5
       parent: 1
-  - uid: 508
+  - uid: 165
     components:
     - type: Transform
       pos: 4.5,-29.5
       parent: 1
-  - uid: 509
+  - uid: 166
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 1
-  - uid: 510
+  - uid: 167
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 1
-  - uid: 511
+  - uid: 168
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 1
-  - uid: 512
+  - uid: 169
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 1
-  - uid: 513
+  - uid: 170
     components:
     - type: Transform
       pos: -0.5,-29.5
       parent: 1
-  - uid: 514
+  - uid: 171
     components:
     - type: Transform
       pos: -1.5,-29.5
       parent: 1
-  - uid: 515
+  - uid: 172
     components:
     - type: Transform
       pos: -2.5,-29.5
       parent: 1
-  - uid: 516
+  - uid: 173
     components:
     - type: Transform
       pos: -3.5,-29.5
       parent: 1
-  - uid: 517
+  - uid: 174
     components:
     - type: Transform
       pos: -4.5,-29.5
       parent: 1
-  - uid: 518
+  - uid: 175
     components:
     - type: Transform
       pos: -5.5,-29.5
       parent: 1
-  - uid: 519
+  - uid: 176
     components:
     - type: Transform
       pos: -6.5,-29.5
       parent: 1
-  - uid: 520
+  - uid: 177
     components:
     - type: Transform
       pos: -7.5,-29.5
       parent: 1
-  - uid: 521
+  - uid: 178
     components:
     - type: Transform
       pos: -6.5,-30.5
       parent: 1
-  - uid: 522
+  - uid: 179
     components:
     - type: Transform
       pos: -6.5,-31.5
       parent: 1
-  - uid: 523
+  - uid: 180
     components:
     - type: Transform
       pos: -6.5,-32.5
       parent: 1
-  - uid: 524
+  - uid: 181
     components:
     - type: Transform
       pos: 5.5,-30.5
       parent: 1
-  - uid: 525
+  - uid: 182
     components:
     - type: Transform
       pos: 5.5,-31.5
       parent: 1
-  - uid: 526
+  - uid: 183
     components:
     - type: Transform
       pos: 5.5,-32.5
       parent: 1
-  - uid: 527
+  - uid: 184
     components:
     - type: Transform
       pos: -0.5,-28.5
       parent: 1
-  - uid: 528
+  - uid: 185
     components:
     - type: Transform
       pos: -0.5,-27.5
       parent: 1
-  - uid: 529
+  - uid: 186
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
-  - uid: 530
+  - uid: 187
     components:
     - type: Transform
       pos: -0.5,-25.5
       parent: 1
-  - uid: 531
+  - uid: 188
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
-  - uid: 532
+  - uid: 189
     components:
     - type: Transform
       pos: -2.5,-30.5
       parent: 1
-  - uid: 533
+  - uid: 190
     components:
     - type: Transform
       pos: -2.5,-31.5
       parent: 1
-  - uid: 534
+  - uid: 191
     components:
     - type: Transform
       pos: -2.5,-32.5
       parent: 1
-  - uid: 535
+  - uid: 192
     components:
     - type: Transform
       pos: -2.5,-33.5
       parent: 1
-  - uid: 536
+  - uid: 193
     components:
     - type: Transform
       pos: -2.5,-34.5
       parent: 1
-  - uid: 537
+  - uid: 194
     components:
     - type: Transform
       pos: -2.5,-35.5
       parent: 1
-  - uid: 538
+  - uid: 195
     components:
     - type: Transform
       pos: 1.5,-35.5
       parent: 1
-  - uid: 539
+  - uid: 196
     components:
     - type: Transform
       pos: 1.5,-34.5
       parent: 1
-  - uid: 540
+  - uid: 197
     components:
     - type: Transform
       pos: 1.5,-33.5
       parent: 1
-  - uid: 541
+  - uid: 198
     components:
     - type: Transform
       pos: 1.5,-32.5
       parent: 1
-  - uid: 542
+  - uid: 199
     components:
     - type: Transform
       pos: 1.5,-31.5
       parent: 1
-  - uid: 543
+  - uid: 200
     components:
     - type: Transform
       pos: 1.5,-30.5
       parent: 1
-  - uid: 544
+  - uid: 201
     components:
     - type: Transform
       pos: 0.5,-35.5
       parent: 1
-  - uid: 545
+  - uid: 202
     components:
     - type: Transform
       pos: -0.5,-35.5
       parent: 1
-  - uid: 546
+  - uid: 203
     components:
     - type: Transform
       pos: -1.5,-35.5
       parent: 1
-  - uid: 547
+  - uid: 204
     components:
     - type: Transform
       pos: -0.5,-36.5
       parent: 1
-  - uid: 548
+  - uid: 205
     components:
     - type: Transform
       pos: -0.5,-37.5
       parent: 1
-  - uid: 549
+  - uid: 206
     components:
     - type: Transform
       pos: -0.5,-38.5
       parent: 1
-  - uid: 550
+  - uid: 207
     components:
     - type: Transform
       pos: -0.5,-39.5
       parent: 1
-  - uid: 551
+  - uid: 208
     components:
     - type: Transform
       pos: -2.5,-28.5
       parent: 1
-  - uid: 552
+  - uid: 209
     components:
     - type: Transform
       pos: -2.5,-27.5
       parent: 1
-  - uid: 553
+  - uid: 210
     components:
     - type: Transform
       pos: -2.5,-26.5
       parent: 1
-  - uid: 554
+  - uid: 211
     components:
     - type: Transform
       pos: -2.5,-25.5
       parent: 1
-  - uid: 555
+  - uid: 212
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 1
-  - uid: 556
+  - uid: 213
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 1
-  - uid: 557
+  - uid: 214
     components:
     - type: Transform
       pos: 1.5,-25.5
       parent: 1
-  - uid: 558
+  - uid: 215
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 1
-  - uid: 559
+  - uid: 216
     components:
     - type: Transform
       pos: 2.5,-25.5
       parent: 1
-  - uid: 560
+  - uid: 217
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 1
-  - uid: 561
+  - uid: 218
     components:
     - type: Transform
       pos: 2.5,-23.5
       parent: 1
-  - uid: 562
+  - uid: 219
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 1
-  - uid: 563
+  - uid: 220
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 1
-  - uid: 564
+  - uid: 221
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 1
-  - uid: 565
+  - uid: 222
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 1
-  - uid: 566
+  - uid: 223
     components:
     - type: Transform
       pos: 2.5,-18.5
       parent: 1
-  - uid: 567
+  - uid: 224
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
-  - uid: 568
+  - uid: 225
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 569
+  - uid: 226
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
-  - uid: 570
+  - uid: 227
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 571
+  - uid: 228
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 572
+  - uid: 229
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 573
+  - uid: 230
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 574
+  - uid: 231
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 575
+  - uid: 232
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 576
+  - uid: 233
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 577
+  - uid: 234
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 578
+  - uid: 235
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
-  - uid: 579
+  - uid: 236
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
-  - uid: 580
+  - uid: 237
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 581
+  - uid: 238
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 582
+  - uid: 239
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 583
+  - uid: 240
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 584
+  - uid: 241
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 585
+  - uid: 242
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 1
-  - uid: 586
+  - uid: 243
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
-  - uid: 587
+  - uid: 244
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 1
-  - uid: 588
+  - uid: 245
     components:
     - type: Transform
       pos: -3.5,-23.5
       parent: 1
-  - uid: 589
+  - uid: 246
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 1
-  - uid: 590
+  - uid: 247
     components:
     - type: Transform
       pos: -3.5,-25.5
       parent: 1
-  - uid: 591
+  - uid: 248
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 592
+  - uid: 249
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 593
+  - uid: 250
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 594
+  - uid: 251
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 595
+  - uid: 252
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 596
+  - uid: 253
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 597
+  - uid: 254
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 598
+  - uid: 255
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 599
+  - uid: 256
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 600
+  - uid: 257
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 601
+  - uid: 258
     components:
     - type: Transform
       pos: 3.5,-24.5
       parent: 1
-  - uid: 602
+  - uid: 259
     components:
     - type: Transform
       pos: 4.5,-24.5
       parent: 1
-  - uid: 603
+  - uid: 260
     components:
     - type: Transform
       pos: 4.5,-23.5
       parent: 1
-  - uid: 604
+  - uid: 261
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 1
-  - uid: 605
+  - uid: 262
     components:
     - type: Transform
       pos: -5.5,-24.5
       parent: 1
-  - uid: 606
+  - uid: 263
     components:
     - type: Transform
       pos: -5.5,-23.5
       parent: 1
-  - uid: 607
+  - uid: 264
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 1
-  - uid: 608
+  - uid: 265
     components:
     - type: Transform
       pos: 5.5,-27.5
       parent: 1
-  - uid: 609
+  - uid: 266
     components:
     - type: Transform
       pos: 5.5,-26.5
       parent: 1
-  - uid: 610
+  - uid: 267
     components:
     - type: Transform
       pos: -6.5,-28.5
       parent: 1
-  - uid: 611
+  - uid: 268
     components:
     - type: Transform
       pos: -6.5,-27.5
       parent: 1
-  - uid: 612
+  - uid: 269
     components:
     - type: Transform
       pos: -6.5,-26.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 493
+  - uid: 270
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 1
-  - uid: 494
+  - uid: 271
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 1
-  - uid: 495
+  - uid: 272
     components:
     - type: Transform
       pos: 3.5,-28.5
       parent: 1
-  - uid: 496
+  - uid: 273
     components:
     - type: Transform
       pos: 3.5,-27.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 497
+  - uid: 274
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 1
-  - uid: 498
+  - uid: 275
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 1
-  - uid: 499
+  - uid: 276
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 1
-  - uid: 500
+  - uid: 277
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 1
-  - uid: 501
+  - uid: 278
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 1
-  - uid: 502
+  - uid: 279
     components:
     - type: Transform
       pos: -0.5,-29.5
       parent: 1
-  - uid: 503
+  - uid: 280
     components:
     - type: Transform
       pos: -0.5,-28.5
       parent: 1
-  - uid: 504
+  - uid: 281
     components:
     - type: Transform
       pos: -0.5,-27.5
       parent: 1
-  - uid: 505
+  - uid: 282
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 359
+  - uid: 283
     components:
     - type: Transform
       pos: 3.5,-27.5
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 65
+  - uid: 284
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
-  - uid: 66
+  - uid: 285
     components:
     - type: Transform
       pos: -0.5,-25.5
       parent: 1
-  - uid: 67
+  - uid: 286
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 1
-  - uid: 68
+  - uid: 287
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 69
+  - uid: 288
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 70
+  - uid: 289
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 71
+  - uid: 290
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 72
+  - uid: 291
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 73
+  - uid: 292
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 74
+  - uid: 293
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 75
+  - uid: 294
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 76
+  - uid: 295
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 77
+  - uid: 296
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 78
+  - uid: 297
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
-  - uid: 79
+  - uid: 298
     components:
     - type: Transform
       pos: -1.5,-19.5
       parent: 1
-  - uid: 80
+  - uid: 299
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
-  - uid: 81
+  - uid: 300
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 1
-  - uid: 106
+  - uid: 301
     components:
     - type: Transform
       pos: 4.5,-32.5
       parent: 1
-  - uid: 107
+  - uid: 302
     components:
     - type: Transform
       pos: 5.5,-33.5
       parent: 1
-  - uid: 108
+  - uid: 303
     components:
     - type: Transform
       pos: 6.5,-34.5
       parent: 1
-  - uid: 109
+  - uid: 304
     components:
     - type: Transform
       pos: -5.5,-32.5
       parent: 1
-  - uid: 110
+  - uid: 305
     components:
     - type: Transform
       pos: -6.5,-33.5
       parent: 1
-  - uid: 111
+  - uid: 306
     components:
     - type: Transform
       pos: -7.5,-34.5
       parent: 1
-  - uid: 112
+  - uid: 307
     components:
     - type: Transform
       pos: -9.5,-30.5
       parent: 1
-  - uid: 113
+  - uid: 308
     components:
     - type: Transform
       pos: -9.5,-29.5
       parent: 1
-  - uid: 114
+  - uid: 309
     components:
     - type: Transform
       pos: -9.5,-28.5
       parent: 1
-  - uid: 115
+  - uid: 310
     components:
     - type: Transform
       pos: 8.5,-28.5
       parent: 1
-  - uid: 116
+  - uid: 311
     components:
     - type: Transform
       pos: 8.5,-29.5
       parent: 1
-  - uid: 117
+  - uid: 312
     components:
     - type: Transform
       pos: 8.5,-30.5
       parent: 1
-  - uid: 122
+  - uid: 313
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
-  - uid: 236
+  - uid: 314
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 237
+  - uid: 315
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 238
+  - uid: 316
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 239
+  - uid: 317
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
-  - uid: 244
+  - uid: 318
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 1
-  - uid: 394
+  - uid: 319
     components:
     - type: Transform
       pos: 0.5,-34.5
       parent: 1
-  - uid: 395
+  - uid: 320
     components:
     - type: Transform
       pos: 0.5,-33.5
       parent: 1
-  - uid: 399
+  - uid: 321
     components:
     - type: Transform
       pos: 0.5,-31.5
       parent: 1
-  - uid: 400
+  - uid: 322
     components:
     - type: Transform
       pos: 0.5,-30.5
       parent: 1
-  - uid: 401
+  - uid: 323
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 1
-  - uid: 403
+  - uid: 324
     components:
     - type: Transform
       pos: -0.5,-29.5
       parent: 1
-  - uid: 404
+  - uid: 325
     components:
     - type: Transform
       pos: -0.5,-30.5
       parent: 1
-  - uid: 405
+  - uid: 326
     components:
     - type: Transform
       pos: -0.5,-31.5
       parent: 1
-  - uid: 406
+  - uid: 327
     components:
     - type: Transform
       pos: -0.5,-32.5
       parent: 1
-  - uid: 407
+  - uid: 328
     components:
     - type: Transform
       pos: -0.5,-34.5
       parent: 1
-  - uid: 409
+  - uid: 329
     components:
     - type: Transform
       pos: -0.5,-33.5
       parent: 1
-  - uid: 414
+  - uid: 330
     components:
     - type: Transform
       pos: 0.5,-32.5
       parent: 1
-  - uid: 469
+  - uid: 331
     components:
     - type: Transform
       pos: -1.5,-30.5
       parent: 1
-  - uid: 481
+  - uid: 332
     components:
     - type: Transform
       pos: -1.5,-29.5
       parent: 1
-  - uid: 490
+  - uid: 333
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 491
+  - uid: 334
     components:
     - type: Transform
       pos: 4.5,-23.5
       parent: 1
-  - uid: 492
+  - uid: 335
     components:
     - type: Transform
       pos: 4.5,-24.5
       parent: 1
-  - uid: 613
+  - uid: 336
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
-  - uid: 614
+  - uid: 337
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 615
+  - uid: 338
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
-  - uid: 616
+  - uid: 339
     components:
     - type: Transform
       pos: 2.5,-18.5
       parent: 1
-  - uid: 617
+  - uid: 340
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 1
-  - uid: 618
+  - uid: 341
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 1
-  - uid: 619
+  - uid: 342
     components:
     - type: Transform
       pos: -0.5,-37.5
       parent: 1
-  - uid: 620
+  - uid: 343
     components:
     - type: Transform
       pos: 0.5,-38.5
       parent: 1
-  - uid: 621
+  - uid: 344
     components:
     - type: Transform
       pos: 0.5,-37.5
       parent: 1
-  - uid: 623
+  - uid: 345
     components:
     - type: Transform
       pos: -1.5,-34.5
       parent: 1
-  - uid: 624
+  - uid: 346
     components:
     - type: Transform
       pos: -1.5,-33.5
       parent: 1
-  - uid: 625
+  - uid: 347
     components:
     - type: Transform
       pos: -1.5,-32.5
       parent: 1
-  - uid: 626
+  - uid: 348
     components:
     - type: Transform
       pos: -1.5,-31.5
       parent: 1
-  - uid: 628
+  - uid: 349
     components:
     - type: Transform
       pos: -1.5,-37.5
       parent: 1
-  - uid: 629
+  - uid: 350
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
-  - uid: 630
+  - uid: 351
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 631
+  - uid: 352
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 632
+  - uid: 353
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 633
+  - uid: 354
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 634
+  - uid: 355
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 635
+  - uid: 356
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 1
-  - uid: 636
+  - uid: 357
     components:
     - type: Transform
       pos: -0.5,-38.5
       parent: 1
-  - uid: 639
+  - uid: 358
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 1
-  - uid: 640
+  - uid: 359
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
-  - uid: 641
+  - uid: 360
     components:
     - type: Transform
       pos: -1.5,-38.5
       parent: 1
-  - uid: 662
+  - uid: 361
     components:
     - type: Transform
       pos: 6.5,-19.5
       parent: 1
-  - uid: 663
+  - uid: 362
     components:
     - type: Transform
       pos: 6.5,-20.5
       parent: 1
-  - uid: 664
+  - uid: 363
     components:
     - type: Transform
       pos: -7.5,-20.5
       parent: 1
-  - uid: 665
+  - uid: 364
     components:
     - type: Transform
       pos: -7.5,-19.5
       parent: 1
-  - uid: 666
+  - uid: 365
     components:
     - type: Transform
       pos: 6.5,-28.5
       parent: 1
-  - uid: 667
+  - uid: 366
     components:
     - type: Transform
       pos: 6.5,-27.5
       parent: 1
-  - uid: 668
+  - uid: 367
     components:
     - type: Transform
       pos: 6.5,-26.5
       parent: 1
-  - uid: 669
+  - uid: 368
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 1
-  - uid: 670
+  - uid: 369
     components:
     - type: Transform
       pos: 5.5,-27.5
       parent: 1
-  - uid: 671
+  - uid: 370
     components:
     - type: Transform
       pos: 5.5,-26.5
       parent: 1
-  - uid: 672
+  - uid: 371
     components:
     - type: Transform
       pos: 4.5,-28.5
       parent: 1
-  - uid: 673
+  - uid: 372
     components:
     - type: Transform
       pos: 4.5,-27.5
       parent: 1
-  - uid: 674
+  - uid: 373
     components:
     - type: Transform
       pos: 4.5,-26.5
       parent: 1
-  - uid: 675
+  - uid: 374
     components:
     - type: Transform
       pos: 4.5,-22.5
       parent: 1
-  - uid: 680
+  - uid: 375
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 681
+  - uid: 376
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 682
+  - uid: 377
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 683
+  - uid: 378
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 684
+  - uid: 379
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 685
+  - uid: 380
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 688
+  - uid: 381
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 1
-  - uid: 689
+  - uid: 382
     components:
     - type: Transform
       pos: -3.5,-37.5
       parent: 1
-  - uid: 690
+  - uid: 383
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 691
+  - uid: 384
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 694
+  - uid: 385
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2668,7 +2673,7 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 679
+  - uid: 386
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2676,7 +2681,7 @@ entities:
       parent: 1
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 330
+  - uid: 387
     components:
     - type: Transform
       pos: -5.5,-22.5
@@ -2684,10 +2689,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 333
+  - uid: 388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2696,35 +2700,19 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 307
+  - uid: 389
     components:
     - type: Transform
       pos: -6.5,-22.5
       parent: 1
-    - type: ShuttleConsoleLock
-      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
-    - type: DeviceLinkSource
-      linkedPorts: {}
-      lastSignals: {}
-      ports:
-      - device-button-1
-      - device-button-2
-      - device-button-3
-      - device-button-4
-      - device-button-5
-      - device-button-6
-      - device-button-7
-      - device-button-8
 - proto: ComputerWallmountRadar
   entities:
-  - uid: 329
+  - uid: 390
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2733,10 +2721,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerWallmountStationRecords
   entities:
-  - uid: 332
+  - uid: 391
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2745,31 +2732,30 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 686
+  - uid: 392
     components:
     - type: Transform
       pos: 0.5,-27.5
       parent: 1
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 687
+  - uid: 393
     components:
     - type: Transform
       pos: -1.5,-27.5
       parent: 1
 - proto: FaxMachineShipAntag
   entities:
-  - uid: 678
+  - uid: 394
     components:
     - type: Transform
       pos: -5.5,-25.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 717
+  - uid: 395
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2777,19 +2763,19 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 712
-      - 713
-      - 710
-      - 711
-  - uid: 718
+      - 404
+      - 405
+      - 402
+      - 403
+  - uid: 396
     components:
     - type: Transform
       pos: -5.5,-26.5
       parent: 1
     - type: DeviceList
       devices:
-      - 711
-  - uid: 721
+      - 403
+  - uid: 397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2797,8 +2783,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 710
-  - uid: 722
+      - 402
+  - uid: 398
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2806,9 +2792,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 713
-      - 715
-  - uid: 723
+      - 405
+      - 407
+  - uid: 399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2816,9 +2802,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 712
-      - 714
-  - uid: 727
+      - 404
+      - 406
+  - uid: 400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2826,8 +2812,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 715
-  - uid: 730
+      - 407
+  - uid: 401
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2835,78 +2821,78 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 714
+      - 406
 - proto: Firelock
   entities:
-  - uid: 710
+  - uid: 402
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 717
-      - 716
-      - 721
-      - 720
-  - uid: 711
+      - 395
+      - 2
+      - 397
+      - 4
+  - uid: 403
     components:
     - type: Transform
       pos: -3.5,-29.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 717
-      - 716
-      - 718
-      - 719
-  - uid: 712
+      - 395
+      - 2
+      - 396
+      - 3
+  - uid: 404
     components:
     - type: Transform
       pos: -2.5,-27.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 717
-      - 716
-      - 723
-      - 724
-  - uid: 713
+      - 395
+      - 2
+      - 399
+      - 5
+  - uid: 405
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 717
-      - 716
-      - 722
-      - 725
-  - uid: 714
+      - 395
+      - 2
+      - 398
+      - 6
+  - uid: 406
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 723
-      - 724
-      - 730
-      - 729
-  - uid: 715
+      - 399
+      - 5
+      - 401
+      - 8
+  - uid: 407
     components:
     - type: Transform
       pos: 3.5,-24.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 722
-      - 725
-      - 727
-      - 726
+      - 398
+      - 6
+      - 400
+      - 7
 - proto: FloorDrain
   entities:
-  - uid: 650
+  - uid: 408
     components:
     - type: Transform
       pos: -6.5,-30.5
@@ -2915,7 +2901,7 @@ entities:
       fixtures: {}
 - proto: GasMixerOnFlipped
   entities:
-  - uid: 364
+  - uid: 409
     components:
     - type: Transform
       pos: 5.5,-29.5
@@ -2927,7 +2913,7 @@ entities:
       color: '#00AACCFF'
 - proto: GasPassiveGate
   entities:
-  - uid: 380
+  - uid: 410
     components:
     - type: Transform
       pos: 6.5,-32.5
@@ -2936,7 +2922,7 @@ entities:
       color: '#DD0075FF'
 - proto: GasPassiveVent
   entities:
-  - uid: 382
+  - uid: 411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2944,27 +2930,27 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 363
+  - uid: 412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-29.5
       parent: 1
-  - uid: 368
+  - uid: 413
     components:
     - type: Transform
       pos: 6.5,-28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 376
+  - uid: 414
     components:
     - type: Transform
       pos: 6.5,-30.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 386
+  - uid: 415
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2972,7 +2958,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 387
+  - uid: 416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2980,7 +2966,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 433
+  - uid: 417
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2988,7 +2974,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 434
+  - uid: 418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2996,14 +2982,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 435
+  - uid: 419
     components:
     - type: Transform
       pos: -2.5,-25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 436
+  - uid: 420
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3011,7 +2997,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 439
+  - uid: 421
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3019,14 +3005,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 440
+  - uid: 422
     components:
     - type: Transform
       pos: -1.5,-24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 462
+  - uid: 423
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3034,7 +3020,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 463
+  - uid: 424
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3042,7 +3028,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 464
+  - uid: 425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3050,14 +3036,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 465
+  - uid: 426
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 466
+  - uid: 427
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3065,14 +3051,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 471
+  - uid: 428
     components:
     - type: Transform
       pos: -5.5,-29.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 484
+  - uid: 429
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3082,14 +3068,14 @@ entities:
       color: '#DD0075FF'
 - proto: GasPipeFourway
   entities:
-  - uid: 369
+  - uid: 430
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 410
+  - uid: 431
     components:
     - type: Transform
       pos: -1.5,-30.5
@@ -3098,14 +3084,14 @@ entities:
       color: '#DD0075FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 334
+  - uid: 432
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 370
+  - uid: 433
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3113,7 +3099,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 371
+  - uid: 434
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3121,7 +3107,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 372
+  - uid: 435
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3129,7 +3115,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 377
+  - uid: 436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3137,7 +3123,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 378
+  - uid: 437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3145,7 +3131,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 379
+  - uid: 438
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3153,13 +3139,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 381
+  - uid: 439
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-33.5
       parent: 1
-  - uid: 383
+  - uid: 440
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3167,7 +3153,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 384
+  - uid: 441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3175,21 +3161,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 388
+  - uid: 442
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 389
+  - uid: 443
     components:
     - type: Transform
       pos: 0.5,-28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 390
+  - uid: 444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3197,7 +3183,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 391
+  - uid: 445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3205,7 +3191,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 392
+  - uid: 446
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3213,7 +3199,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 393
+  - uid: 447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3221,7 +3207,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 396
+  - uid: 448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3229,7 +3215,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 397
+  - uid: 449
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3237,7 +3223,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 398
+  - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3245,7 +3231,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 402
+  - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3253,7 +3239,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 411
+  - uid: 452
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3261,7 +3247,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 412
+  - uid: 453
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3269,7 +3255,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 415
+  - uid: 454
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3277,7 +3263,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 416
+  - uid: 455
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3285,7 +3271,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 417
+  - uid: 456
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3293,7 +3279,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 418
+  - uid: 457
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3301,7 +3287,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 419
+  - uid: 458
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3309,7 +3295,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 420
+  - uid: 459
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3317,7 +3303,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 421
+  - uid: 460
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3325,70 +3311,70 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 422
+  - uid: 461
     components:
     - type: Transform
       pos: 0.5,-26.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 423
+  - uid: 462
     components:
     - type: Transform
       pos: 0.5,-27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 424
+  - uid: 463
     components:
     - type: Transform
       pos: 0.5,-25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 425
+  - uid: 464
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 426
+  - uid: 465
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 427
+  - uid: 466
     components:
     - type: Transform
       pos: -2.5,-27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 428
+  - uid: 467
     components:
     - type: Transform
       pos: -2.5,-26.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 429
+  - uid: 468
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 431
+  - uid: 469
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 441
+  - uid: 470
     components:
     - type: Transform
       anchored: False
@@ -3397,7 +3383,7 @@ entities:
     - type: Physics
       canCollide: True
       bodyType: Dynamic
-  - uid: 442
+  - uid: 471
     components:
     - type: Transform
       anchored: False
@@ -3406,7 +3392,7 @@ entities:
     - type: Physics
       canCollide: True
       bodyType: Dynamic
-  - uid: 443
+  - uid: 472
     components:
     - type: Transform
       anchored: False
@@ -3415,7 +3401,7 @@ entities:
     - type: Physics
       canCollide: True
       bodyType: Dynamic
-  - uid: 444
+  - uid: 473
     components:
     - type: Transform
       anchored: False
@@ -3424,7 +3410,7 @@ entities:
     - type: Physics
       canCollide: True
       bodyType: Dynamic
-  - uid: 445
+  - uid: 474
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3432,7 +3418,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 446
+  - uid: 475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3440,7 +3426,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 447
+  - uid: 476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3448,7 +3434,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 448
+  - uid: 477
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3456,7 +3442,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 449
+  - uid: 478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3464,7 +3450,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 450
+  - uid: 479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3472,84 +3458,84 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 451
+  - uid: 480
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 452
+  - uid: 481
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 453
+  - uid: 482
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 454
+  - uid: 483
     components:
     - type: Transform
       pos: -2.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 455
+  - uid: 484
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 456
+  - uid: 485
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 457
+  - uid: 486
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 458
+  - uid: 487
     components:
     - type: Transform
       pos: 1.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 459
+  - uid: 488
     components:
     - type: Transform
       pos: 1.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 460
+  - uid: 489
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 461
+  - uid: 490
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 467
+  - uid: 491
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3557,7 +3543,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 480
+  - uid: 492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3567,14 +3553,14 @@ entities:
       color: '#DD0075FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 367
+  - uid: 493
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 375
+  - uid: 494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3582,7 +3568,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 385
+  - uid: 495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3590,7 +3576,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 430
+  - uid: 496
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3598,7 +3584,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 432
+  - uid: 497
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3606,7 +3592,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 437
+  - uid: 498
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3614,7 +3600,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 438
+  - uid: 499
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3622,7 +3608,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 470
+  - uid: 500
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3632,13 +3618,13 @@ entities:
       color: '#00AACCFF'
 - proto: GasPort
   entities:
-  - uid: 365
+  - uid: 501
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-30.5
       parent: 1
-  - uid: 366
+  - uid: 502
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3646,7 +3632,7 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 373
+  - uid: 503
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3654,10 +3640,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 720
+      - 4
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 408
+  - uid: 504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3665,40 +3651,40 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 716
+      - 2
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 474
+  - uid: 505
     components:
     - type: Transform
       pos: 4.5,-22.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 726
+      - 7
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 475
+  - uid: 506
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 725
+      - 6
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 476
+  - uid: 507
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 724
+      - 5
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 477
+  - uid: 508
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3706,10 +3692,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 729
+      - 8
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 482
+  - uid: 509
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3717,22 +3703,22 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 719
+      - 3
     - type: AtmosPipeColor
       color: '#00AACCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 374
+  - uid: 510
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 720
+      - 4
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 413
+  - uid: 511
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3740,20 +3726,20 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 716
+      - 2
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 468
+  - uid: 512
     components:
     - type: Transform
       pos: 2.5,-18.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 725
+      - 6
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 472
+  - uid: 513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3761,10 +3747,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 729
+      - 8
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 473
+  - uid: 514
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3772,20 +3758,20 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 726
+      - 7
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 478
+  - uid: 515
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 724
+      - 5
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 483
+  - uid: 516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3793,144 +3779,144 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 719
+      - 3
     - type: AtmosPipeColor
       color: '#DD0075FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 308
+  - uid: 517
     components:
     - type: Transform
       pos: 5.5,-24.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 94
+  - uid: 518
     components:
     - type: Transform
       pos: -10.5,-30.5
       parent: 1
-  - uid: 100
+  - uid: 519
     components:
     - type: Transform
       pos: 9.5,-30.5
       parent: 1
-  - uid: 104
+  - uid: 520
     components:
     - type: Transform
       pos: 9.5,-29.5
       parent: 1
-  - uid: 105
+  - uid: 521
     components:
     - type: Transform
       pos: -10.5,-29.5
       parent: 1
-  - uid: 278
+  - uid: 522
     components:
     - type: Transform
       pos: 1.5,-22.5
       parent: 1
-  - uid: 279
+  - uid: 523
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
-  - uid: 479
+  - uid: 524
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 1
-  - uid: 485
+  - uid: 525
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 486
+  - uid: 526
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 487
+  - uid: 527
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 1
-  - uid: 488
+  - uid: 528
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
-  - uid: 489
+  - uid: 529
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 95
+  - uid: 530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-33.5
       parent: 1
-  - uid: 96
+  - uid: 531
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-34.5
       parent: 1
-  - uid: 97
+  - uid: 532
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-35.5
       parent: 1
-  - uid: 98
+  - uid: 533
     components:
     - type: Transform
       pos: -10.5,-28.5
       parent: 1
-  - uid: 99
+  - uid: 534
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-28.5
       parent: 1
-  - uid: 101
+  - uid: 535
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-33.5
       parent: 1
-  - uid: 102
+  - uid: 536
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-34.5
       parent: 1
-  - uid: 103
+  - uid: 537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-35.5
       parent: 1
-  - uid: 132
+  - uid: 538
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 138
+  - uid: 539
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 234
+  - uid: 540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 235
+  - uid: 541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3938,57 +3924,61 @@ entities:
       parent: 1
 - proto: GunneryServerMedium
   entities:
-  - uid: 676
+  - uid: 542
     components:
     - type: Transform
       pos: 6.5,-30.5
       parent: 1
+    - type: Battery
+      startingCharge: 0
+    - type: ApcPowerReceiver
+      powerLoad: 10
 - proto: GyroscopeSecurity
   entities:
-  - uid: 295
+  - uid: 543
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 1
-  - uid: 296
+  - uid: 544
     components:
     - type: Transform
       pos: 4.5,-20.5
       parent: 1
-  - uid: 297
+  - uid: 545
     components:
     - type: Transform
       pos: -5.5,-18.5
       parent: 1
-  - uid: 298
+  - uid: 546
     components:
     - type: Transform
       pos: -5.5,-20.5
       parent: 1
 - proto: KitchenAssembler
   entities:
-  - uid: 648
+  - uid: 547
     components:
     - type: Transform
       pos: -7.5,-29.5
       parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 646
+  - uid: 548
     components:
     - type: Transform
       pos: -7.5,-30.5
       parent: 1
 - proto: LockerSteel
   entities:
-  - uid: 653
+  - uid: 549
     components:
     - type: Transform
       pos: -5.5,-30.5
       parent: 1
 - proto: LockerWallMaterialsFuelAmeJarFilled
   entities:
-  - uid: 361
+  - uid: 550
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3996,21 +3986,21 @@ entities:
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 245
+  - uid: 551
     components:
     - type: Transform
       pos: 5.5,-22.5
       parent: 1
 - proto: NFHolopadShipAntag
   entities:
-  - uid: 677
+  - uid: 552
     components:
     - type: Transform
       pos: -5.5,-24.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 362
+  - uid: 553
     components:
     - type: Transform
       anchored: True
@@ -4020,14 +4010,14 @@ entities:
       bodyType: Static
 - proto: OreProcessor
   entities:
-  - uid: 643
+  - uid: 554
     components:
     - type: Transform
       pos: -7.5,-28.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 358
+  - uid: 555
     components:
     - type: Transform
       anchored: True
@@ -4037,25 +4027,25 @@ entities:
       bodyType: Static
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 240
+  - uid: 556
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 1
-  - uid: 241
+  - uid: 557
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 242
+  - uid: 558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 243
+  - uid: 559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4063,80 +4053,73 @@ entities:
       parent: 1
 - proto: PlastitaniumWindow
   entities:
-  - uid: 20
+  - uid: 560
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 24
+  - uid: 561
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 25
+  - uid: 562
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
-  - uid: 26
+  - uid: 563
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 1
-  - uid: 45
+  - uid: 564
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 1
-  - uid: 46
+  - uid: 565
     components:
     - type: Transform
       pos: 1.5,-22.5
       parent: 1
-  - uid: 50
+  - uid: 566
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
-  - uid: 52
+  - uid: 567
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
-- proto: PowerCellRecharger
-  entities:
-  - uid: 642
-    components:
-    - type: Transform
-      pos: -4.5,-27.5
-      parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 850
+  - uid: 570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-23.5
       parent: 1
-  - uid: 852
+  - uid: 571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-20.5
       parent: 1
-  - uid: 853
+  - uid: 572
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-18.5
       parent: 1
-  - uid: 854
+  - uid: 573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-18.5
       parent: 1
-  - uid: 855
+  - uid: 574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4144,7 +4127,7 @@ entities:
       parent: 1
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 851
+  - uid: 575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4152,13 +4135,13 @@ entities:
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 842
+  - uid: 576
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-32.5
       parent: 1
-  - uid: 843
+  - uid: 577
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4166,36 +4149,36 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 844
+  - uid: 578
     components:
     - type: Transform
       pos: -6.5,-27.5
       parent: 1
-  - uid: 845
+  - uid: 579
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-29.5
       parent: 1
-  - uid: 846
+  - uid: 580
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-15.5
       parent: 1
-  - uid: 847
+  - uid: 581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-15.5
       parent: 1
-  - uid: 848
+  - uid: 582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-25.5
       parent: 1
-  - uid: 849
+  - uid: 583
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4203,37 +4186,37 @@ entities:
       parent: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 841
+  - uid: 584
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 1
-  - uid: 856
+  - uid: 585
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-19.5
       parent: 1
-  - uid: 857
+  - uid: 586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 858
+  - uid: 587
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 859
+  - uid: 588
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-19.5
       parent: 1
-  - uid: 860
+  - uid: 589
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4241,7 +4224,7 @@ entities:
       parent: 1
 - proto: ShelfWallFreezerDark
   entities:
-  - uid: 647
+  - uid: 590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4249,7 +4232,7 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 649
+  - uid: 591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4257,41 +4240,41 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 357
+  - uid: 592
     components:
     - type: Transform
       pos: 3.5,-28.5
       parent: 1
-- proto: SpawnPointPirate
+- proto: SpawnPointNFPirate
   entities:
-  - uid: 695
+  - uid: 593
     components:
     - type: Transform
       pos: -4.5,-29.5
       parent: 1
-- proto: SpawnPointPirateCaptain
+- proto: SpawnPointNFPirateCaptain
   entities:
-  - uid: 696
+  - uid: 594
     components:
     - type: Transform
       pos: -4.5,-29.5
       parent: 1
-- proto: SpawnPointPirateFirstMate
+- proto: SpawnPointNFPirateFirstMate
   entities:
-  - uid: 697
+  - uid: 595
     components:
     - type: Transform
       pos: -4.5,-29.5
       parent: 1
 - proto: Stairs
   entities:
-  - uid: 637
+  - uid: 596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-22.5
       parent: 1
-  - uid: 638
+  - uid: 597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4299,446 +4282,446 @@ entities:
       parent: 1
 - proto: StructureGunRack
   entities:
-  - uid: 266
+  - uid: 598
     components:
     - type: Transform
       pos: -4.5,-14.5
       parent: 1
-  - uid: 267
+  - uid: 599
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 360
+  - uid: 600
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 1
 - proto: SuitStorageEVAPirate
   entities:
-  - uid: 268
+  - uid: 601
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 269
+  - uid: 602
     components:
     - type: Transform
       pos: -4.5,-15.5
       parent: 1
 - proto: Table
   entities:
-  - uid: 651
+  - uid: 603
     components:
     - type: Transform
       pos: -7.5,-29.5
       parent: 1
-  - uid: 652
+  - uid: 604
     components:
     - type: Transform
       pos: -7.5,-30.5
       parent: 1
-  - uid: 659
+  - uid: 605
     components:
     - type: Transform
       pos: -4.5,-27.5
       parent: 1
-  - uid: 660
+  - uid: 606
     components:
     - type: Transform
       pos: -4.5,-28.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 331
+  - uid: 607
     components:
     - type: Transform
       pos: -5.5,-25.5
       parent: 1
 - proto: ThrusterSecurity
   entities:
-  - uid: 82
+  - uid: 608
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-28.5
       parent: 1
-  - uid: 83
+  - uid: 609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-29.5
       parent: 1
-  - uid: 84
+  - uid: 610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-30.5
       parent: 1
-  - uid: 85
+  - uid: 611
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-33.5
       parent: 1
-  - uid: 86
+  - uid: 612
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-34.5
       parent: 1
-  - uid: 87
+  - uid: 613
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-32.5
       parent: 1
-  - uid: 88
+  - uid: 614
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-33.5
       parent: 1
-  - uid: 89
+  - uid: 615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-32.5
       parent: 1
-  - uid: 90
+  - uid: 616
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-34.5
       parent: 1
-  - uid: 91
+  - uid: 617
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-30.5
       parent: 1
-  - uid: 92
+  - uid: 618
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-29.5
       parent: 1
-  - uid: 93
+  - uid: 619
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-28.5
       parent: 1
-  - uid: 118
+  - uid: 620
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 230
+  - uid: 621
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 231
+  - uid: 622
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 232
+  - uid: 623
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 274
+  - uid: 624
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
-  - uid: 275
+  - uid: 625
     components:
     - type: Transform
       pos: -4.5,-16.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 3
+  - uid: 626
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 4
+  - uid: 627
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 5
+  - uid: 628
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 6
+  - uid: 629
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 7
+  - uid: 630
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 8
+  - uid: 631
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 9
+  - uid: 632
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 10
+  - uid: 633
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 11
+  - uid: 634
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 12
+  - uid: 635
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 13
+  - uid: 636
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 14
+  - uid: 637
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 15
+  - uid: 638
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 16
+  - uid: 639
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 17
+  - uid: 640
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 18
+  - uid: 641
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 1
-  - uid: 19
+  - uid: 642
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 1
-  - uid: 21
+  - uid: 643
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
-  - uid: 22
+  - uid: 644
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 1
-  - uid: 23
+  - uid: 645
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 1
-  - uid: 27
+  - uid: 646
     components:
     - type: Transform
       pos: 1.5,-23.5
       parent: 1
-  - uid: 28
+  - uid: 647
     components:
     - type: Transform
       pos: 1.5,-24.5
       parent: 1
-  - uid: 29
+  - uid: 648
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 30
+  - uid: 649
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 31
+  - uid: 650
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 32
+  - uid: 651
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 33
+  - uid: 652
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 34
+  - uid: 653
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 35
+  - uid: 654
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 36
+  - uid: 655
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 37
+  - uid: 656
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 38
+  - uid: 657
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 39
+  - uid: 658
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 40
+  - uid: 659
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 1
-  - uid: 41
+  - uid: 660
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
-  - uid: 42
+  - uid: 661
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 43
+  - uid: 662
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 44
+  - uid: 663
     components:
     - type: Transform
       pos: -2.5,-15.5
       parent: 1
-  - uid: 47
+  - uid: 664
     components:
     - type: Transform
       pos: -2.5,-18.5
       parent: 1
-  - uid: 48
+  - uid: 665
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
-  - uid: 49
+  - uid: 666
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 1
-  - uid: 51
+  - uid: 667
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 53
+  - uid: 668
     components:
     - type: Transform
       pos: -2.5,-23.5
       parent: 1
-  - uid: 54
+  - uid: 669
     components:
     - type: Transform
       pos: -2.5,-24.5
       parent: 1
-  - uid: 55
+  - uid: 670
     components:
     - type: Transform
       pos: -1.5,-24.5
       parent: 1
-  - uid: 56
+  - uid: 671
     components:
     - type: Transform
       pos: -1.5,-25.5
       parent: 1
-  - uid: 57
+  - uid: 672
     components:
     - type: Transform
       pos: -1.5,-26.5
       parent: 1
-  - uid: 58
+  - uid: 673
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
-  - uid: 59
+  - uid: 674
     components:
     - type: Transform
       pos: 0.5,-26.5
       parent: 1
-  - uid: 60
+  - uid: 675
     components:
     - type: Transform
       pos: 0.5,-25.5
       parent: 1
-  - uid: 61
+  - uid: 676
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 2
+  - uid: 677
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 62
+  - uid: 678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
-  - uid: 276
+  - uid: 679
     components:
     - type: Transform
       pos: 0.5,-23.5
       parent: 1
-  - uid: 277
+  - uid: 680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4746,864 +4729,864 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 119
+  - uid: 681
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 120
+  - uid: 682
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 121
+  - uid: 683
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 123
+  - uid: 684
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 125
+  - uid: 685
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 126
+  - uid: 686
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 127
+  - uid: 687
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 128
+  - uid: 688
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 129
+  - uid: 689
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 130
+  - uid: 690
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 131
+  - uid: 691
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 133
+  - uid: 692
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 1
-  - uid: 135
+  - uid: 693
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 1
-  - uid: 136
+  - uid: 694
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 137
+  - uid: 695
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 139
+  - uid: 696
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
-  - uid: 140
+  - uid: 697
     components:
     - type: Transform
       pos: 4.5,-14.5
       parent: 1
-  - uid: 141
+  - uid: 698
     components:
     - type: Transform
       pos: 4.5,-15.5
       parent: 1
-  - uid: 142
+  - uid: 699
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 143
+  - uid: 700
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 144
+  - uid: 701
     components:
     - type: Transform
       pos: 5.5,-17.5
       parent: 1
-  - uid: 145
+  - uid: 702
     components:
     - type: Transform
       pos: 5.5,-18.5
       parent: 1
-  - uid: 146
+  - uid: 703
     components:
     - type: Transform
       pos: 5.5,-19.5
       parent: 1
-  - uid: 147
+  - uid: 704
     components:
     - type: Transform
       pos: 5.5,-20.5
       parent: 1
-  - uid: 149
+  - uid: 705
     components:
     - type: Transform
       pos: 6.5,-21.5
       parent: 1
-  - uid: 150
+  - uid: 706
     components:
     - type: Transform
       pos: 6.5,-22.5
       parent: 1
-  - uid: 151
+  - uid: 707
     components:
     - type: Transform
       pos: 6.5,-23.5
       parent: 1
-  - uid: 152
+  - uid: 708
     components:
     - type: Transform
       pos: 6.5,-24.5
       parent: 1
-  - uid: 153
+  - uid: 709
     components:
     - type: Transform
       pos: 7.5,-24.5
       parent: 1
-  - uid: 154
+  - uid: 710
     components:
     - type: Transform
       pos: 7.5,-25.5
       parent: 1
-  - uid: 155
+  - uid: 711
     components:
     - type: Transform
       pos: 7.5,-26.5
       parent: 1
-  - uid: 156
+  - uid: 712
     components:
     - type: Transform
       pos: 7.5,-27.5
       parent: 1
-  - uid: 157
+  - uid: 713
     components:
     - type: Transform
       pos: 8.5,-27.5
       parent: 1
-  - uid: 158
+  - uid: 714
     components:
     - type: Transform
       pos: 7.5,-28.5
       parent: 1
-  - uid: 159
+  - uid: 715
     components:
     - type: Transform
       pos: 7.5,-29.5
       parent: 1
-  - uid: 160
+  - uid: 716
     components:
     - type: Transform
       pos: 7.5,-30.5
       parent: 1
-  - uid: 161
+  - uid: 717
     components:
     - type: Transform
       pos: 7.5,-31.5
       parent: 1
-  - uid: 162
+  - uid: 718
     components:
     - type: Transform
       pos: 7.5,-32.5
       parent: 1
-  - uid: 163
+  - uid: 719
     components:
     - type: Transform
       pos: 8.5,-31.5
       parent: 1
-  - uid: 164
+  - uid: 720
     components:
     - type: Transform
       pos: 8.5,-32.5
       parent: 1
-  - uid: 165
+  - uid: 721
     components:
     - type: Transform
       pos: 7.5,-33.5
       parent: 1
-  - uid: 166
+  - uid: 722
     components:
     - type: Transform
       pos: 7.5,-34.5
       parent: 1
-  - uid: 167
+  - uid: 723
     components:
     - type: Transform
       pos: 7.5,-35.5
       parent: 1
-  - uid: 168
+  - uid: 724
     components:
     - type: Transform
       pos: 6.5,-33.5
       parent: 1
-  - uid: 169
+  - uid: 725
     components:
     - type: Transform
       pos: 5.5,-32.5
       parent: 1
-  - uid: 170
+  - uid: 726
     components:
     - type: Transform
       pos: 4.5,-31.5
       parent: 1
-  - uid: 171
+  - uid: 727
     components:
     - type: Transform
       pos: -5.5,-31.5
       parent: 1
-  - uid: 172
+  - uid: 728
     components:
     - type: Transform
       pos: -6.5,-32.5
       parent: 1
-  - uid: 173
+  - uid: 729
     components:
     - type: Transform
       pos: -7.5,-33.5
       parent: 1
-  - uid: 174
+  - uid: 730
     components:
     - type: Transform
       pos: -8.5,-35.5
       parent: 1
-  - uid: 175
+  - uid: 731
     components:
     - type: Transform
       pos: -8.5,-34.5
       parent: 1
-  - uid: 176
+  - uid: 732
     components:
     - type: Transform
       pos: -8.5,-33.5
       parent: 1
-  - uid: 177
+  - uid: 733
     components:
     - type: Transform
       pos: -9.5,-32.5
       parent: 1
-  - uid: 178
+  - uid: 734
     components:
     - type: Transform
       pos: -9.5,-31.5
       parent: 1
-  - uid: 179
+  - uid: 735
     components:
     - type: Transform
       pos: -8.5,-32.5
       parent: 1
-  - uid: 180
+  - uid: 736
     components:
     - type: Transform
       pos: -8.5,-31.5
       parent: 1
-  - uid: 181
+  - uid: 737
     components:
     - type: Transform
       pos: -8.5,-30.5
       parent: 1
-  - uid: 182
+  - uid: 738
     components:
     - type: Transform
       pos: -8.5,-29.5
       parent: 1
-  - uid: 183
+  - uid: 739
     components:
     - type: Transform
       pos: -8.5,-28.5
       parent: 1
-  - uid: 184
+  - uid: 740
     components:
     - type: Transform
       pos: -8.5,-27.5
       parent: 1
-  - uid: 185
+  - uid: 741
     components:
     - type: Transform
       pos: -9.5,-27.5
       parent: 1
-  - uid: 186
+  - uid: 742
     components:
     - type: Transform
       pos: -8.5,-26.5
       parent: 1
-  - uid: 187
+  - uid: 743
     components:
     - type: Transform
       pos: -8.5,-25.5
       parent: 1
-  - uid: 188
+  - uid: 744
     components:
     - type: Transform
       pos: -8.5,-24.5
       parent: 1
-  - uid: 189
+  - uid: 745
     components:
     - type: Transform
       pos: -7.5,-24.5
       parent: 1
-  - uid: 190
+  - uid: 746
     components:
     - type: Transform
       pos: -7.5,-23.5
       parent: 1
-  - uid: 191
+  - uid: 747
     components:
     - type: Transform
       pos: -7.5,-22.5
       parent: 1
-  - uid: 192
+  - uid: 748
     components:
     - type: Transform
       pos: -7.5,-21.5
       parent: 1
-  - uid: 194
+  - uid: 749
     components:
     - type: Transform
       pos: -6.5,-20.5
       parent: 1
-  - uid: 195
+  - uid: 750
     components:
     - type: Transform
       pos: -6.5,-19.5
       parent: 1
-  - uid: 196
+  - uid: 751
     components:
     - type: Transform
       pos: -6.5,-18.5
       parent: 1
-  - uid: 197
+  - uid: 752
     components:
     - type: Transform
       pos: -6.5,-17.5
       parent: 1
-  - uid: 198
+  - uid: 753
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 199
+  - uid: 754
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 1
-  - uid: 200
+  - uid: 755
     components:
     - type: Transform
       pos: -5.5,-15.5
       parent: 1
-  - uid: 201
+  - uid: 756
     components:
     - type: Transform
       pos: -5.5,-14.5
       parent: 1
-  - uid: 202
+  - uid: 757
     components:
     - type: Transform
       pos: -5.5,-13.5
       parent: 1
-  - uid: 203
+  - uid: 758
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 204
+  - uid: 759
     components:
     - type: Transform
       pos: -6.5,-31.5
       parent: 1
-  - uid: 205
+  - uid: 760
     components:
     - type: Transform
       pos: -7.5,-32.5
       parent: 1
-  - uid: 206
+  - uid: 761
     components:
     - type: Transform
       pos: 5.5,-31.5
       parent: 1
-  - uid: 207
+  - uid: 762
     components:
     - type: Transform
       pos: 6.5,-32.5
       parent: 1
-  - uid: 208
+  - uid: 763
     components:
     - type: Transform
       pos: 3.5,-31.5
       parent: 1
-  - uid: 209
+  - uid: 764
     components:
     - type: Transform
       pos: 3.5,-32.5
       parent: 1
-  - uid: 210
+  - uid: 765
     components:
     - type: Transform
       pos: 3.5,-33.5
       parent: 1
-  - uid: 211
+  - uid: 766
     components:
     - type: Transform
       pos: 3.5,-34.5
       parent: 1
-  - uid: 212
+  - uid: 767
     components:
     - type: Transform
       pos: -4.5,-31.5
       parent: 1
-  - uid: 213
+  - uid: 768
     components:
     - type: Transform
       pos: -4.5,-32.5
       parent: 1
-  - uid: 214
+  - uid: 769
     components:
     - type: Transform
       pos: -4.5,-33.5
       parent: 1
-  - uid: 215
+  - uid: 770
     components:
     - type: Transform
       pos: -4.5,-34.5
       parent: 1
-  - uid: 216
+  - uid: 771
     components:
     - type: Transform
       pos: -3.5,-35.5
       parent: 1
-  - uid: 217
+  - uid: 772
     components:
     - type: Transform
       pos: -3.5,-36.5
       parent: 1
-  - uid: 218
+  - uid: 773
     components:
     - type: Transform
       pos: 2.5,-34.5
       parent: 1
-  - uid: 219
+  - uid: 774
     components:
     - type: Transform
       pos: 2.5,-35.5
       parent: 1
-  - uid: 220
+  - uid: 775
     components:
     - type: Transform
       pos: 2.5,-36.5
       parent: 1
-  - uid: 221
+  - uid: 776
     components:
     - type: Transform
       pos: -3.5,-34.5
       parent: 1
-  - uid: 222
+  - uid: 777
     components:
     - type: Transform
       pos: -2.5,-36.5
       parent: 1
-  - uid: 223
+  - uid: 778
     components:
     - type: Transform
       pos: -2.5,-37.5
       parent: 1
-  - uid: 224
+  - uid: 779
     components:
     - type: Transform
       pos: -2.5,-38.5
       parent: 1
-  - uid: 225
+  - uid: 780
     components:
     - type: Transform
       pos: -2.5,-39.5
       parent: 1
-  - uid: 226
+  - uid: 781
     components:
     - type: Transform
       pos: 1.5,-39.5
       parent: 1
-  - uid: 227
+  - uid: 782
     components:
     - type: Transform
       pos: 1.5,-38.5
       parent: 1
-  - uid: 228
+  - uid: 783
     components:
     - type: Transform
       pos: 1.5,-37.5
       parent: 1
-  - uid: 229
+  - uid: 784
     components:
     - type: Transform
       pos: 1.5,-36.5
       parent: 1
-  - uid: 262
+  - uid: 785
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 263
+  - uid: 786
     components:
     - type: Transform
       pos: -4.5,-13.5
       parent: 1
-  - uid: 270
+  - uid: 787
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1
-  - uid: 271
+  - uid: 788
     components:
     - type: Transform
       pos: 3.5,-17.5
       parent: 1
-  - uid: 272
+  - uid: 789
     components:
     - type: Transform
       pos: -5.5,-17.5
       parent: 1
-  - uid: 273
+  - uid: 790
     components:
     - type: Transform
       pos: -4.5,-17.5
       parent: 1
-  - uid: 280
+  - uid: 791
     components:
     - type: Transform
       pos: 4.5,-19.5
       parent: 1
-  - uid: 281
+  - uid: 792
     components:
     - type: Transform
       pos: 3.5,-19.5
       parent: 1
-  - uid: 282
+  - uid: 793
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 1
-  - uid: 283
+  - uid: 794
     components:
     - type: Transform
       pos: 4.5,-21.5
       parent: 1
-  - uid: 284
+  - uid: 795
     components:
     - type: Transform
       pos: 5.5,-21.5
       parent: 1
-  - uid: 285
+  - uid: 796
     components:
     - type: Transform
       pos: -6.5,-21.5
       parent: 1
-  - uid: 286
+  - uid: 797
     components:
     - type: Transform
       pos: -5.5,-21.5
       parent: 1
-  - uid: 287
+  - uid: 798
     components:
     - type: Transform
       pos: -4.5,-21.5
       parent: 1
-  - uid: 288
+  - uid: 799
     components:
     - type: Transform
       pos: -5.5,-19.5
       parent: 1
-  - uid: 289
+  - uid: 800
     components:
     - type: Transform
       pos: -4.5,-19.5
       parent: 1
-  - uid: 294
+  - uid: 801
     components:
     - type: Transform
       pos: -4.5,-22.5
       parent: 1
-  - uid: 299
+  - uid: 802
     components:
     - type: Transform
       pos: 3.5,-22.5
       parent: 1
-  - uid: 300
+  - uid: 803
     components:
     - type: Transform
       pos: 5.5,-23.5
       parent: 1
-  - uid: 301
+  - uid: 804
     components:
     - type: Transform
       pos: 6.5,-25.5
       parent: 1
-  - uid: 302
+  - uid: 805
     components:
     - type: Transform
       pos: 5.5,-25.5
       parent: 1
-  - uid: 303
+  - uid: 806
     components:
     - type: Transform
       pos: 4.5,-25.5
       parent: 1
-  - uid: 304
+  - uid: 807
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 1
-  - uid: 305
+  - uid: 808
     components:
     - type: Transform
       pos: 3.5,-23.5
       parent: 1
-  - uid: 309
+  - uid: 809
     components:
     - type: Transform
       pos: 3.5,-26.5
       parent: 1
-  - uid: 310
+  - uid: 810
     components:
     - type: Transform
       pos: 2.5,-26.5
       parent: 1
-  - uid: 311
+  - uid: 811
     components:
     - type: Transform
       pos: 2.5,-27.5
       parent: 1
-  - uid: 312
+  - uid: 812
     components:
     - type: Transform
       pos: 2.5,-28.5
       parent: 1
-  - uid: 313
+  - uid: 813
     components:
     - type: Transform
       pos: -1.5,-27.5
       parent: 1
-  - uid: 317
+  - uid: 814
     components:
     - type: Transform
       pos: 0.5,-27.5
       parent: 1
-  - uid: 318
+  - uid: 815
     components:
     - type: Transform
       pos: -3.5,-28.5
       parent: 1
-  - uid: 319
+  - uid: 816
     components:
     - type: Transform
       pos: -3.5,-27.5
       parent: 1
-  - uid: 320
+  - uid: 817
     components:
     - type: Transform
       pos: -3.5,-26.5
       parent: 1
-  - uid: 321
+  - uid: 818
     components:
     - type: Transform
       pos: -4.5,-26.5
       parent: 1
-  - uid: 322
+  - uid: 819
     components:
     - type: Transform
       pos: -4.5,-23.5
       parent: 1
-  - uid: 323
+  - uid: 820
     components:
     - type: Transform
       pos: -5.5,-26.5
       parent: 1
-  - uid: 324
+  - uid: 821
     components:
     - type: Transform
       pos: -6.5,-26.5
       parent: 1
-  - uid: 325
+  - uid: 822
     components:
     - type: Transform
       pos: -7.5,-26.5
       parent: 1
-  - uid: 326
+  - uid: 823
     components:
     - type: Transform
       pos: -7.5,-25.5
       parent: 1
-  - uid: 328
+  - uid: 824
     components:
     - type: Transform
       pos: -4.5,-25.5
       parent: 1
-  - uid: 335
+  - uid: 825
     components:
     - type: Transform
       pos: -3.5,-31.5
       parent: 1
-  - uid: 336
+  - uid: 826
     components:
     - type: Transform
       pos: -3.5,-30.5
       parent: 1
-  - uid: 337
+  - uid: 827
     components:
     - type: Transform
       pos: 2.5,-31.5
       parent: 1
-  - uid: 338
+  - uid: 828
     components:
     - type: Transform
       pos: 2.5,-30.5
       parent: 1
-  - uid: 339
+  - uid: 829
     components:
     - type: Transform
       pos: 2.5,-32.5
       parent: 1
-  - uid: 340
+  - uid: 830
     components:
     - type: Transform
       pos: 2.5,-33.5
       parent: 1
-  - uid: 341
+  - uid: 831
     components:
     - type: Transform
       pos: -3.5,-32.5
       parent: 1
-  - uid: 342
+  - uid: 832
     components:
     - type: Transform
       pos: -3.5,-33.5
       parent: 1
-  - uid: 344
+  - uid: 833
     components:
     - type: Transform
       pos: 6.5,-31.5
       parent: 1
-  - uid: 345
+  - uid: 834
     components:
     - type: Transform
       pos: -7.5,-31.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 63
+  - uid: 835
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-15.5
       parent: 1
-  - uid: 193
+  - uid: 836
     components:
     - type: Transform
       pos: -7.5,-20.5
       parent: 1
-  - uid: 233
+  - uid: 837
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 1
-  - uid: 247
+  - uid: 838
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-23.5
       parent: 1
-  - uid: 248
+  - uid: 839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-26.5
       parent: 1
-  - uid: 249
+  - uid: 840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-33.5
       parent: 1
-  - uid: 250
+  - uid: 841
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-36.5
       parent: 1
-  - uid: 251
+  - uid: 842
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-35.5
       parent: 1
-  - uid: 254
+  - uid: 843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-35.5
       parent: 1
-  - uid: 255
+  - uid: 844
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-36.5
       parent: 1
-  - uid: 256
+  - uid: 845
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-33.5
       parent: 1
-  - uid: 257
+  - uid: 846
     components:
     - type: Transform
       pos: -9.5,-26.5
       parent: 1
-  - uid: 258
+  - uid: 847
     components:
     - type: Transform
       pos: -8.5,-23.5
       parent: 1
-  - uid: 259
+  - uid: 848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-20.5
       parent: 1
-  - uid: 260
+  - uid: 849
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
-  - uid: 261
+  - uid: 850
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5611,21 +5594,26 @@ entities:
       parent: 1
 - proto: WarpPointAdmin
   entities:
-  - uid: 698
+  - uid: 851
     components:
     - type: Transform
       pos: -0.5,-25.5
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 661
+  - uid: 568
+    components:
+    - type: Transform
+      pos: -4.5,-27.5
+      parent: 1
+  - uid: 569
     components:
     - type: Transform
       pos: -4.5,-28.5
       parent: 1
 - proto: WeaponTurretCharon
   entities:
-  - uid: 64
+  - uid: 852
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5633,23 +5621,23 @@ entities:
       parent: 1
 - proto: WeaponTurretL85Autocannon
   entities:
-  - uid: 252
+  - uid: 853
     components:
     - type: Transform
       pos: -3.5,-37.5
       parent: 1
-  - uid: 253
+  - uid: 854
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 1
-  - uid: 692
+  - uid: 855
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-11.5
       parent: 1
-  - uid: 693
+  - uid: 856
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5657,13 +5645,13 @@ entities:
       parent: 1
 - proto: WeaponTurretVespera
   entities:
-  - uid: 148
+  - uid: 857
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-19.5
       parent: 1
-  - uid: 246
+  - uid: 858
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5671,12 +5659,12 @@ entities:
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 654
+  - uid: 859
     components:
     - type: Transform
       pos: -4.5,-28.5
       parent: 1
-  - uid: 656
+  - uid: 860
     components:
     - type: Transform
       pos: -7.5,-28.5

--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/europa.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/europa.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/21/2025 01:25:16
-  entityCount: 1245
+  time: 06/29/2025 02:08:54
+  entityCount: 1246
 maps: []
 grids:
 - 1
@@ -78,6 +78,7 @@ entities:
       id: Europa
     - type: OccluderTree
     - type: Shuttle
+      dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -1003,7 +1004,20 @@ entities:
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
-  - uid: 597
+  - uid: 9
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: -0.5005393,-11.017001
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 598
     components:
     - type: MetaData
     - type: Transform
@@ -1018,25 +1032,25 @@ entities:
     - type: CircularShieldRadar
 - proto: AirAlarm
   entities:
-  - uid: 9
+  - uid: 10
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
     - type: DeviceList
       devices:
+      - 624
       - 623
-      - 622
-      - 620
-      - 616
-      - 618
-      - 626
+      - 621
+      - 617
+      - 619
       - 627
-      - 802
-      - 814
-      - 818
-      - 794
-  - uid: 10
+      - 628
+      - 803
+      - 815
+      - 819
+      - 795
+  - uid: 11
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1044,10 +1058,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 624
-      - 807
-      - 795
-  - uid: 11
+      - 625
+      - 808
+      - 796
+  - uid: 12
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1055,12 +1069,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 617
-      - 619
       - 618
-      - 806
-      - 793
-  - uid: 12
+      - 620
+      - 619
+      - 807
+      - 794
+  - uid: 13
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1068,12 +1082,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 621
-      - 625
-      - 619
-      - 797
-      - 812
-  - uid: 13
+      - 622
+      - 626
+      - 620
+      - 798
+      - 813
+  - uid: 14
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1081,14 +1095,14 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 620
-      - 624
       - 621
-      - 798
-      - 811
+      - 625
+      - 622
       - 799
-      - 810
-  - uid: 14
+      - 812
+      - 800
+      - 811
+  - uid: 15
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1096,10 +1110,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 625
-      - 813
-      - 796
-  - uid: 15
+      - 626
+      - 814
+      - 797
+  - uid: 16
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1107,13 +1121,13 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
+      - 618
       - 617
-      - 616
+      - 802
       - 801
-      - 800
+      - 810
       - 809
-      - 808
-  - uid: 16
+  - uid: 17
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1121,10 +1135,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 622
-      - 803
-      - 815
-  - uid: 17
+      - 623
+      - 804
+      - 816
+  - uid: 18
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1132,138 +1146,138 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 622
-      - 803
-      - 815
-      - 626
-      - 627
-      - 805
-      - 817
-      - 816
+      - 623
       - 804
-- proto: AirlockExternalGlassRogueLocked
+      - 816
+      - 627
+      - 628
+      - 806
+      - 818
+      - 817
+      - 805
+- proto: AirlockExternalGlassPirateLocked
   entities:
-  - uid: 18
+  - uid: 19
     components:
     - type: Transform
       pos: -7.5,-11.5
       parent: 1
-  - uid: 19
+  - uid: 20
     components:
     - type: Transform
       pos: -7.5,-12.5
       parent: 1
-  - uid: 20
+  - uid: 21
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 21
+  - uid: 22
     components:
     - type: Transform
       pos: 6.5,-12.5
       parent: 1
-- proto: AirlockHatchRogueLocked
+- proto: AirlockGlassShuttleSyndicate
   entities:
-  - uid: 22
-    components:
-    - type: Transform
-      pos: 3.5,-24.5
-      parent: 1
-  - uid: 23
-    components:
-    - type: Transform
-      pos: -4.5,-24.5
-      parent: 1
-  - uid: 24
-    components:
-    - type: Transform
-      pos: -2.5,-7.5
-      parent: 1
-  - uid: 25
-    components:
-    - type: Transform
-      pos: -4.5,-20.5
-      parent: 1
-  - uid: 26
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1
-  - uid: 27
-    components:
-    - type: Transform
-      pos: 3.5,-5.5
-      parent: 1
-  - uid: 28
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 29
-    components:
-    - type: Transform
-      pos: -4.5,2.5
-      parent: 1
-  - uid: 30
-    components:
-    - type: Transform
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 31
-    components:
-    - type: Transform
-      pos: -0.5,-15.5
-      parent: 1
-  - uid: 32
-    components:
-    - type: Transform
-      pos: 2.5,-15.5
-      parent: 1
-  - uid: 33
-    components:
-    - type: Transform
-      pos: -3.5,-20.5
-      parent: 1
-  - uid: 34
-    components:
-    - type: Transform
-      pos: -4.5,-10.5
-      parent: 1
-  - uid: 35
-    components:
-    - type: Transform
-      pos: -4.5,-4.5
-      parent: 1
-- proto: AirlockShuttleSyndicateRogueLocked
-  entities:
-  - uid: 36
+  - uid: 37
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-11.5
       parent: 1
-  - uid: 37
+  - uid: 38
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-12.5
       parent: 1
-  - uid: 38
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-11.5
-      parent: 1
-  - uid: 39
+  - uid: 40
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-12.5
       parent: 1
+  - uid: 998
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-11.5
+      parent: 1
+- proto: AirlockHatchPirateLocked
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 3.5,-24.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -4.5,-24.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -4.5,-20.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 2.5,-15.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,-20.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
 - proto: AmeController
   entities:
-  - uid: 40
+  - uid: 41
     components:
     - type: Transform
       pos: 1.5,-21.5
@@ -1275,33 +1289,33 @@ entities:
         fuelSlot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 41
+          ent: 42
 - proto: AmeJar
-  entities:
-  - uid: 41
-    components:
-    - type: Transform
-      parent: 40
-    - type: Physics
-      canCollide: False
-- proto: AmeShielding
   entities:
   - uid: 42
     components:
     - type: Transform
-      pos: 0.5,-23.5
-      parent: 1
+      parent: 41
+    - type: Physics
+      canCollide: False
+- proto: AmeShielding
+  entities:
   - uid: 43
     components:
     - type: Transform
-      pos: 0.5,-22.5
+      pos: 0.5,-23.5
       parent: 1
   - uid: 44
     components:
     - type: Transform
-      pos: 0.5,-21.5
+      pos: 0.5,-22.5
       parent: 1
   - uid: 45
+    components:
+    - type: Transform
+      pos: 0.5,-21.5
+      parent: 1
+  - uid: 46
     components:
     - type: Transform
       pos: -0.5,-22.5
@@ -1309,87 +1323,87 @@ entities:
     - type: PointLight
       radius: 2
       enabled: True
-  - uid: 46
+  - uid: 47
     components:
     - type: Transform
       pos: -0.5,-23.5
       parent: 1
-  - uid: 47
+  - uid: 48
     components:
     - type: Transform
       pos: -1.5,-21.5
       parent: 1
-  - uid: 48
+  - uid: 49
     components:
     - type: Transform
       pos: -0.5,-21.5
       parent: 1
-  - uid: 49
+  - uid: 50
     components:
     - type: Transform
       pos: -1.5,-23.5
       parent: 1
-  - uid: 50
+  - uid: 51
     components:
     - type: Transform
       pos: -1.5,-22.5
       parent: 1
 - proto: AmmoTechFab
   entities:
-  - uid: 51
+  - uid: 52
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 52
+  - uid: 53
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-18.5
       parent: 1
-  - uid: 53
+  - uid: 54
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-19.5
       parent: 1
-  - uid: 54
+  - uid: 55
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-9.5
       parent: 1
-  - uid: 55
+  - uid: 56
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-18.5
       parent: 1
-  - uid: 56
+  - uid: 57
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 57
+  - uid: 58
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 58
+  - uid: 59
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-18.5
       parent: 1
-  - uid: 59
+  - uid: 60
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-24.5
       parent: 1
-  - uid: 60
+  - uid: 61
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1397,37 +1411,37 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 61
+  - uid: 62
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-  - uid: 62
+  - uid: 63
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-12.5
       parent: 1
-  - uid: 63
+  - uid: 64
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-12.5
       parent: 1
-  - uid: 64
+  - uid: 65
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-11.5
       parent: 1
-  - uid: 65
+  - uid: 66
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-0.5
       parent: 1
-  - uid: 66
+  - uid: 67
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1435,580 +1449,580 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 67
+  - uid: 68
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
-  - uid: 68
+  - uid: 69
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 69
+  - uid: 70
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 1
-  - uid: 70
+  - uid: 71
     components:
     - type: Transform
       pos: 6.5,-16.5
       parent: 1
-  - uid: 71
+  - uid: 72
     components:
     - type: Transform
       pos: 7.5,-14.5
       parent: 1
-  - uid: 72
+  - uid: 73
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 1
-  - uid: 73
+  - uid: 74
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
-  - uid: 74
+  - uid: 75
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 75
+  - uid: 76
     components:
     - type: Transform
       pos: -7.5,-15.5
       parent: 1
-  - uid: 76
+  - uid: 77
     components:
     - type: Transform
       pos: -7.5,-16.5
       parent: 1
-  - uid: 77
+  - uid: 78
     components:
     - type: Transform
       pos: -8.5,-14.5
       parent: 1
-  - uid: 78
+  - uid: 79
     components:
     - type: Transform
       pos: -8.5,-17.5
       parent: 1
-  - uid: 79
+  - uid: 80
     components:
     - type: Transform
       pos: -9.5,-18.5
       parent: 1
-  - uid: 80
+  - uid: 81
     components:
     - type: Transform
       pos: -9.5,-19.5
       parent: 1
-  - uid: 81
+  - uid: 82
     components:
     - type: Transform
       pos: 8.5,-18.5
       parent: 1
-  - uid: 82
+  - uid: 83
     components:
     - type: Transform
       pos: 8.5,-19.5
       parent: 1
-  - uid: 83
+  - uid: 84
     components:
     - type: Transform
       pos: 9.5,-20.5
       parent: 1
-  - uid: 84
+  - uid: 85
     components:
     - type: Transform
       pos: 9.5,-21.5
       parent: 1
-  - uid: 85
+  - uid: 86
     components:
     - type: Transform
       pos: 9.5,-22.5
       parent: 1
-  - uid: 86
+  - uid: 87
     components:
     - type: Transform
       pos: 9.5,-23.5
       parent: 1
-  - uid: 87
+  - uid: 88
     components:
     - type: Transform
       pos: 8.5,-21.5
       parent: 1
-  - uid: 88
+  - uid: 89
     components:
     - type: Transform
       pos: 8.5,-22.5
       parent: 1
-  - uid: 89
+  - uid: 90
     components:
     - type: Transform
       pos: 8.5,-23.5
       parent: 1
-  - uid: 90
+  - uid: 91
     components:
     - type: Transform
       pos: 7.5,-21.5
       parent: 1
-  - uid: 91
+  - uid: 92
     components:
     - type: Transform
       pos: 7.5,-22.5
       parent: 1
-  - uid: 92
+  - uid: 93
     components:
     - type: Transform
       pos: 7.5,-23.5
       parent: 1
-  - uid: 93
+  - uid: 94
     components:
     - type: Transform
       pos: 9.5,-24.5
       parent: 1
-  - uid: 94
+  - uid: 95
     components:
     - type: Transform
       pos: -8.5,-23.5
       parent: 1
-  - uid: 95
+  - uid: 96
     components:
     - type: Transform
       pos: -8.5,-22.5
       parent: 1
-  - uid: 96
+  - uid: 97
     components:
     - type: Transform
       pos: -8.5,-21.5
       parent: 1
-  - uid: 97
+  - uid: 98
     components:
     - type: Transform
       pos: -9.5,-23.5
       parent: 1
-  - uid: 98
+  - uid: 99
     components:
     - type: Transform
       pos: -9.5,-22.5
       parent: 1
-  - uid: 99
+  - uid: 100
     components:
     - type: Transform
       pos: -9.5,-21.5
       parent: 1
-  - uid: 100
+  - uid: 101
     components:
     - type: Transform
       pos: -10.5,-23.5
       parent: 1
-  - uid: 101
+  - uid: 102
     components:
     - type: Transform
       pos: -10.5,-22.5
       parent: 1
-  - uid: 102
+  - uid: 103
     components:
     - type: Transform
       pos: -10.5,-21.5
       parent: 1
-  - uid: 103
+  - uid: 104
     components:
     - type: Transform
       pos: -10.5,-24.5
       parent: 1
-  - uid: 104
+  - uid: 105
     components:
     - type: Transform
       pos: -8.5,-25.5
       parent: 1
-  - uid: 105
+  - uid: 106
     components:
     - type: Transform
       pos: -7.5,-26.5
       parent: 1
-  - uid: 106
+  - uid: 107
     components:
     - type: Transform
       pos: -5.5,-28.5
       parent: 1
-  - uid: 107
+  - uid: 108
     components:
     - type: Transform
       pos: 4.5,-28.5
       parent: 1
-  - uid: 108
+  - uid: 109
     components:
     - type: Transform
       pos: 6.5,-26.5
       parent: 1
-  - uid: 109
+  - uid: 110
     components:
     - type: Transform
       pos: 7.5,-25.5
       parent: 1
-  - uid: 110
+  - uid: 111
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 1
-  - uid: 111
+  - uid: 112
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 1
-  - uid: 112
+  - uid: 113
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 1
-  - uid: 113
+  - uid: 114
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 1
-  - uid: 114
+  - uid: 115
     components:
     - type: Transform
       pos: -0.5,-29.5
       parent: 1
-  - uid: 115
+  - uid: 116
     components:
     - type: Transform
       pos: -1.5,-29.5
       parent: 1
-  - uid: 116
+  - uid: 117
     components:
     - type: Transform
       pos: -2.5,-29.5
       parent: 1
-  - uid: 117
+  - uid: 118
     components:
     - type: Transform
       pos: -3.5,-29.5
       parent: 1
-  - uid: 118
+  - uid: 119
     components:
     - type: Transform
       pos: -4.5,-30.5
       parent: 1
-  - uid: 119
+  - uid: 120
     components:
     - type: Transform
       pos: -2.5,-27.5
       parent: 1
-  - uid: 120
+  - uid: 121
     components:
     - type: Transform
       pos: -2.5,-26.5
       parent: 1
-  - uid: 121
+  - uid: 122
     components:
     - type: Transform
       pos: -1.5,-27.5
       parent: 1
-  - uid: 122
+  - uid: 123
     components:
     - type: Transform
       pos: -1.5,-26.5
       parent: 1
-  - uid: 123
+  - uid: 124
     components:
     - type: Transform
       pos: -0.5,-27.5
       parent: 1
-  - uid: 124
+  - uid: 125
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
-  - uid: 125
+  - uid: 126
     components:
     - type: Transform
       pos: 0.5,-27.5
       parent: 1
-  - uid: 126
+  - uid: 127
     components:
     - type: Transform
       pos: 0.5,-26.5
       parent: 1
-  - uid: 127
+  - uid: 128
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 1
-  - uid: 128
+  - uid: 129
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 1
-  - uid: 129
+  - uid: 130
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 1
-  - uid: 130
+  - uid: 131
     components:
     - type: Transform
       pos: -9.5,-8.5
       parent: 1
-  - uid: 131
+  - uid: 132
     components:
     - type: Transform
       pos: -9.5,-9.5
       parent: 1
-  - uid: 132
+  - uid: 133
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 1
-  - uid: 133
+  - uid: 134
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 1
-  - uid: 134
+  - uid: 135
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 1
-  - uid: 135
+  - uid: 136
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 1
-  - uid: 136
+  - uid: 137
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 1
-  - uid: 137
+  - uid: 138
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 1
-  - uid: 138
+  - uid: 139
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 1
-  - uid: 139
+  - uid: 140
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 1
-  - uid: 140
+  - uid: 141
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 1
-  - uid: 141
+  - uid: 142
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
-  - uid: 142
+  - uid: 143
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 1
-  - uid: 143
+  - uid: 144
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 1
-  - uid: 144
+  - uid: 145
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
-  - uid: 145
+  - uid: 146
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 1
-  - uid: 146
+  - uid: 147
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
-  - uid: 147
+  - uid: 148
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 148
+  - uid: 149
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 149
+  - uid: 150
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 150
+  - uid: 151
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
-  - uid: 151
+  - uid: 152
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 152
+  - uid: 153
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 1
-  - uid: 153
+  - uid: 154
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
-  - uid: 154
+  - uid: 155
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 1
-  - uid: 155
+  - uid: 156
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 1
-  - uid: 156
+  - uid: 157
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 157
+  - uid: 158
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 158
+  - uid: 159
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 159
+  - uid: 160
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 160
+  - uid: 161
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 161
+  - uid: 162
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 162
+  - uid: 163
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 163
+  - uid: 164
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 164
+  - uid: 165
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 165
+  - uid: 166
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 166
+  - uid: 167
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 167
+  - uid: 168
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 168
+  - uid: 169
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 169
+  - uid: 170
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 170
+  - uid: 171
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 171
+  - uid: 172
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 172
+  - uid: 173
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 173
+  - uid: 174
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 174
+  - uid: 175
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 175
+  - uid: 176
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 176
+  - uid: 177
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
 - proto: Autolathe
   entities:
-  - uid: 177
+  - uid: 178
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 178
+  - uid: 179
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
 - proto: BedsheetBlack
   entities:
-  - uid: 179
+  - uid: 180
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
 - proto: BedsheetMedical
   entities:
-  - uid: 180
+  - uid: 181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2016,19 +2030,19 @@ entities:
       parent: 1
 - proto: BenchComfy
   entities:
-  - uid: 181
+  - uid: 182
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 182
+  - uid: 183
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
 - proto: BenchSofaCorpLeft
   entities:
-  - uid: 183
+  - uid: 184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2036,7 +2050,7 @@ entities:
       parent: 1
 - proto: BenchSofaCorpRight
   entities:
-  - uid: 184
+  - uid: 185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2044,13 +2058,13 @@ entities:
       parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 185
+  - uid: 186
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-1.5
       parent: 1
-  - uid: 186
+  - uid: 187
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2058,7 +2072,7 @@ entities:
       parent: 1
 - proto: ButtonFrameCaution
   entities:
-  - uid: 187
+  - uid: 188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2066,2055 +2080,2055 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 188
+  - uid: 189
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
-  - uid: 189
+  - uid: 190
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
-  - uid: 190
+  - uid: 191
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
-  - uid: 191
+  - uid: 192
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 1
-  - uid: 192
+  - uid: 193
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 1
-  - uid: 193
+  - uid: 194
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 194
+  - uid: 195
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 195
-    components:
-    - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
   - uid: 196
     components:
     - type: Transform
-      pos: 4.5,-18.5
+      pos: 4.5,-2.5
       parent: 1
   - uid: 197
     components:
     - type: Transform
-      pos: 3.5,-18.5
+      pos: 4.5,-18.5
       parent: 1
   - uid: 198
     components:
     - type: Transform
-      pos: 3.5,-17.5
+      pos: 3.5,-18.5
       parent: 1
   - uid: 199
     components:
     - type: Transform
-      pos: 3.5,-16.5
+      pos: 3.5,-17.5
       parent: 1
   - uid: 200
     components:
     - type: Transform
-      pos: -5.5,-18.5
+      pos: 3.5,-16.5
       parent: 1
   - uid: 201
     components:
     - type: Transform
-      pos: -4.5,-18.5
+      pos: -5.5,-18.5
       parent: 1
   - uid: 202
     components:
     - type: Transform
-      pos: -4.5,-17.5
+      pos: -4.5,-18.5
       parent: 1
   - uid: 203
     components:
     - type: Transform
-      pos: -4.5,-16.5
+      pos: -4.5,-17.5
       parent: 1
   - uid: 204
     components:
     - type: Transform
-      pos: -4.5,-19.5
+      pos: -4.5,-16.5
       parent: 1
   - uid: 205
     components:
     - type: Transform
-      pos: -4.5,-20.5
+      pos: -4.5,-19.5
       parent: 1
   - uid: 206
     components:
     - type: Transform
-      pos: -4.5,-15.5
+      pos: -4.5,-20.5
       parent: 1
   - uid: 207
     components:
     - type: Transform
-      pos: -4.5,-14.5
+      pos: -4.5,-15.5
       parent: 1
   - uid: 208
     components:
     - type: Transform
-      pos: -4.5,-13.5
+      pos: -4.5,-14.5
       parent: 1
   - uid: 209
     components:
     - type: Transform
-      pos: -4.5,-12.5
+      pos: -4.5,-13.5
       parent: 1
   - uid: 210
     components:
     - type: Transform
-      pos: -3.5,-12.5
+      pos: -4.5,-12.5
       parent: 1
   - uid: 211
     components:
     - type: Transform
-      pos: -2.5,-12.5
+      pos: -3.5,-12.5
       parent: 1
   - uid: 212
     components:
     - type: Transform
-      pos: -1.5,-12.5
+      pos: -2.5,-12.5
       parent: 1
   - uid: 213
     components:
     - type: Transform
-      pos: -0.5,-12.5
+      pos: -1.5,-12.5
       parent: 1
   - uid: 214
     components:
     - type: Transform
-      pos: 0.5,-12.5
+      pos: -0.5,-12.5
       parent: 1
   - uid: 215
     components:
     - type: Transform
-      pos: 1.5,-12.5
+      pos: 0.5,-12.5
       parent: 1
   - uid: 216
     components:
     - type: Transform
-      pos: 2.5,-12.5
+      pos: 1.5,-12.5
       parent: 1
   - uid: 217
     components:
     - type: Transform
-      pos: 3.5,-12.5
+      pos: 2.5,-12.5
       parent: 1
   - uid: 218
     components:
     - type: Transform
-      pos: 4.5,-12.5
+      pos: 3.5,-12.5
       parent: 1
   - uid: 219
     components:
     - type: Transform
-      pos: 5.5,-12.5
+      pos: 4.5,-12.5
       parent: 1
   - uid: 220
     components:
     - type: Transform
-      pos: -5.5,-12.5
+      pos: 5.5,-12.5
       parent: 1
   - uid: 221
     components:
     - type: Transform
-      pos: -6.5,-12.5
+      pos: -5.5,-12.5
       parent: 1
   - uid: 222
     components:
     - type: Transform
-      pos: -7.5,-12.5
+      pos: -6.5,-12.5
       parent: 1
   - uid: 223
     components:
     - type: Transform
-      pos: -8.5,-12.5
+      pos: -7.5,-12.5
       parent: 1
   - uid: 224
     components:
     - type: Transform
-      pos: -9.5,-12.5
+      pos: -8.5,-12.5
       parent: 1
   - uid: 225
     components:
     - type: Transform
-      pos: 6.5,-12.5
+      pos: -9.5,-12.5
       parent: 1
   - uid: 226
     components:
     - type: Transform
-      pos: 7.5,-12.5
+      pos: 6.5,-12.5
       parent: 1
   - uid: 227
     components:
     - type: Transform
-      pos: 8.5,-12.5
+      pos: 7.5,-12.5
       parent: 1
   - uid: 228
     components:
     - type: Transform
-      pos: 3.5,-11.5
+      pos: 8.5,-12.5
       parent: 1
   - uid: 229
     components:
     - type: Transform
-      pos: 3.5,-10.5
+      pos: 3.5,-11.5
       parent: 1
   - uid: 230
     components:
     - type: Transform
-      pos: 3.5,-9.5
+      pos: 3.5,-10.5
       parent: 1
   - uid: 231
     components:
     - type: Transform
-      pos: 3.5,-8.5
+      pos: 3.5,-9.5
       parent: 1
   - uid: 232
     components:
     - type: Transform
-      pos: 3.5,-7.5
+      pos: 3.5,-8.5
       parent: 1
   - uid: 233
     components:
     - type: Transform
-      pos: 3.5,-6.5
+      pos: 3.5,-7.5
       parent: 1
   - uid: 234
     components:
     - type: Transform
-      pos: -4.5,-11.5
+      pos: 3.5,-6.5
       parent: 1
   - uid: 235
     components:
     - type: Transform
-      pos: -4.5,-10.5
+      pos: -4.5,-11.5
       parent: 1
   - uid: 236
     components:
     - type: Transform
-      pos: -4.5,-9.5
+      pos: -4.5,-10.5
       parent: 1
   - uid: 237
     components:
     - type: Transform
-      pos: -4.5,-8.5
+      pos: -4.5,-9.5
       parent: 1
   - uid: 238
     components:
     - type: Transform
-      pos: -4.5,-7.5
+      pos: -4.5,-8.5
       parent: 1
   - uid: 239
     components:
     - type: Transform
-      pos: -4.5,-6.5
+      pos: -4.5,-7.5
       parent: 1
   - uid: 240
     components:
     - type: Transform
-      pos: -4.5,-5.5
+      pos: -4.5,-6.5
       parent: 1
   - uid: 241
     components:
     - type: Transform
-      pos: -2.5,-9.5
+      pos: -4.5,-5.5
       parent: 1
   - uid: 242
     components:
     - type: Transform
-      pos: -1.5,-9.5
+      pos: -2.5,-9.5
       parent: 1
   - uid: 243
     components:
     - type: Transform
-      pos: -0.5,-9.5
+      pos: -1.5,-9.5
       parent: 1
   - uid: 244
     components:
     - type: Transform
-      pos: 0.5,-9.5
+      pos: -0.5,-9.5
       parent: 1
   - uid: 245
     components:
     - type: Transform
-      pos: 1.5,-9.5
+      pos: 0.5,-9.5
       parent: 1
   - uid: 246
     components:
     - type: Transform
-      pos: -0.5,-8.5
+      pos: 1.5,-9.5
       parent: 1
   - uid: 247
     components:
     - type: Transform
-      pos: -0.5,-7.5
+      pos: -0.5,-8.5
       parent: 1
   - uid: 248
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: -0.5,-7.5
       parent: 1
   - uid: 249
     components:
     - type: Transform
-      pos: 0.5,-7.5
+      pos: -0.5,-6.5
       parent: 1
   - uid: 250
     components:
     - type: Transform
-      pos: 1.5,-7.5
+      pos: 0.5,-7.5
       parent: 1
   - uid: 251
     components:
     - type: Transform
-      pos: 3.5,-4.5
+      pos: 1.5,-7.5
       parent: 1
   - uid: 252
     components:
     - type: Transform
-      pos: 3.5,-3.5
+      pos: 3.5,-4.5
       parent: 1
   - uid: 253
     components:
     - type: Transform
-      pos: 3.5,-2.5
+      pos: 3.5,-3.5
       parent: 1
   - uid: 254
     components:
     - type: Transform
-      pos: 3.5,-1.5
+      pos: 3.5,-2.5
       parent: 1
   - uid: 255
     components:
     - type: Transform
-      pos: 3.5,-0.5
+      pos: 3.5,-1.5
       parent: 1
   - uid: 256
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: 3.5,-0.5
       parent: 1
   - uid: 257
     components:
     - type: Transform
-      pos: 4.5,1.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 258
     components:
     - type: Transform
-      pos: 4.5,2.5
+      pos: 4.5,1.5
       parent: 1
   - uid: 259
     components:
     - type: Transform
-      pos: 4.5,3.5
+      pos: 4.5,2.5
       parent: 1
   - uid: 260
     components:
     - type: Transform
-      pos: 4.5,4.5
+      pos: 4.5,3.5
       parent: 1
   - uid: 261
     components:
     - type: Transform
-      pos: 3.5,4.5
+      pos: 4.5,4.5
       parent: 1
   - uid: 262
     components:
     - type: Transform
-      pos: -4.5,4.5
+      pos: 3.5,4.5
       parent: 1
   - uid: 263
     components:
     - type: Transform
-      pos: -5.5,4.5
+      pos: -4.5,4.5
       parent: 1
   - uid: 264
     components:
     - type: Transform
-      pos: -5.5,3.5
+      pos: -5.5,4.5
       parent: 1
   - uid: 265
     components:
     - type: Transform
-      pos: -5.5,2.5
+      pos: -5.5,3.5
       parent: 1
   - uid: 266
     components:
     - type: Transform
-      pos: -5.5,1.5
+      pos: -5.5,2.5
       parent: 1
   - uid: 267
     components:
     - type: Transform
-      pos: -3.5,4.5
+      pos: -5.5,1.5
       parent: 1
   - uid: 268
     components:
     - type: Transform
-      pos: -4.5,0.5
+      pos: -3.5,4.5
       parent: 1
   - uid: 269
     components:
     - type: Transform
-      pos: -4.5,-0.5
+      pos: -4.5,0.5
       parent: 1
   - uid: 270
     components:
     - type: Transform
-      pos: -4.5,-1.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 271
     components:
     - type: Transform
-      pos: -4.5,-2.5
+      pos: -4.5,-1.5
       parent: 1
   - uid: 272
     components:
     - type: Transform
-      pos: -5.5,-0.5
+      pos: -4.5,-2.5
       parent: 1
   - uid: 273
     components:
     - type: Transform
-      pos: -5.5,-2.5
+      pos: -5.5,-0.5
       parent: 1
   - uid: 274
     components:
     - type: Transform
-      pos: 2.5,-0.5
+      pos: -5.5,-2.5
       parent: 1
   - uid: 275
     components:
     - type: Transform
-      pos: 1.5,-0.5
+      pos: 2.5,-0.5
       parent: 1
   - uid: 276
     components:
     - type: Transform
-      pos: 0.5,-0.5
+      pos: 1.5,-0.5
       parent: 1
   - uid: 277
     components:
     - type: Transform
-      pos: -0.5,-0.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 278
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: -0.5,-0.5
       parent: 1
   - uid: 279
     components:
     - type: Transform
-      pos: 0.5,-2.5
+      pos: -0.5,-2.5
       parent: 1
   - uid: 280
     components:
     - type: Transform
-      pos: 1.5,-2.5
+      pos: 0.5,-2.5
       parent: 1
   - uid: 281
     components:
     - type: Transform
-      pos: 2.5,-2.5
+      pos: 1.5,-2.5
       parent: 1
   - uid: 282
     components:
     - type: Transform
-      pos: 4.5,-2.5
+      pos: 2.5,-2.5
       parent: 1
   - uid: 283
     components:
     - type: Transform
-      pos: 4.5,0.5
+      pos: 4.5,-2.5
       parent: 1
   - uid: 284
     components:
     - type: Transform
-      pos: 5.5,0.5
+      pos: 4.5,0.5
       parent: 1
   - uid: 285
     components:
     - type: Transform
-      pos: 5.5,-2.5
+      pos: 5.5,0.5
       parent: 1
   - uid: 286
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: 5.5,-2.5
       parent: 1
   - uid: 287
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: -0.5,0.5
       parent: 1
   - uid: 288
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: -1.5,0.5
       parent: 1
   - uid: 289
     components:
     - type: Transform
-      pos: -6.5,0.5
+      pos: -1.5,-2.5
       parent: 1
   - uid: 290
     components:
     - type: Transform
-      pos: -6.5,-2.5
+      pos: -6.5,0.5
       parent: 1
   - uid: 291
     components:
     - type: Transform
-      pos: -5.5,0.5
+      pos: -6.5,-2.5
       parent: 1
   - uid: 292
     components:
     - type: Transform
-      pos: 2.5,4.5
+      pos: -5.5,0.5
       parent: 1
   - uid: 293
     components:
     - type: Transform
-      pos: 3.5,5.5
+      pos: 2.5,4.5
       parent: 1
   - uid: 294
     components:
     - type: Transform
-      pos: 3.5,6.5
+      pos: 3.5,5.5
       parent: 1
   - uid: 295
     components:
     - type: Transform
-      pos: -4.5,5.5
+      pos: 3.5,6.5
       parent: 1
   - uid: 296
     components:
     - type: Transform
-      pos: -4.5,6.5
+      pos: -4.5,5.5
       parent: 1
   - uid: 297
     components:
     - type: Transform
-      pos: -5.5,-22.5
+      pos: -4.5,6.5
       parent: 1
   - uid: 298
     components:
     - type: Transform
-      pos: -4.5,-22.5
+      pos: -5.5,-22.5
       parent: 1
   - uid: 299
     components:
     - type: Transform
-      pos: -3.5,-22.5
+      pos: -4.5,-22.5
       parent: 1
   - uid: 300
     components:
     - type: Transform
-      pos: 4.5,-22.5
+      pos: -3.5,-22.5
       parent: 1
   - uid: 301
     components:
     - type: Transform
-      pos: 3.5,-22.5
+      pos: 4.5,-22.5
       parent: 1
   - uid: 302
     components:
     - type: Transform
-      pos: 2.5,-22.5
+      pos: 3.5,-22.5
       parent: 1
   - uid: 303
     components:
     - type: Transform
-      pos: 2.5,-23.5
+      pos: 2.5,-22.5
       parent: 1
   - uid: 304
     components:
     - type: Transform
-      pos: 1.5,-23.5
+      pos: 2.5,-23.5
       parent: 1
   - uid: 305
     components:
     - type: Transform
-      pos: 0.5,-23.5
+      pos: 1.5,-23.5
       parent: 1
   - uid: 306
     components:
     - type: Transform
-      pos: -0.5,-23.5
+      pos: 0.5,-23.5
       parent: 1
   - uid: 307
     components:
     - type: Transform
-      pos: -1.5,-23.5
+      pos: -0.5,-23.5
       parent: 1
   - uid: 308
     components:
     - type: Transform
-      pos: -2.5,-23.5
+      pos: -1.5,-23.5
       parent: 1
   - uid: 309
     components:
     - type: Transform
-      pos: -3.5,-23.5
+      pos: -2.5,-23.5
       parent: 1
   - uid: 310
     components:
     - type: Transform
-      pos: -3.5,-24.5
+      pos: -3.5,-23.5
       parent: 1
   - uid: 311
     components:
     - type: Transform
-      pos: 2.5,-24.5
+      pos: -3.5,-24.5
       parent: 1
   - uid: 312
     components:
     - type: Transform
-      pos: -1.5,-24.5
+      pos: 2.5,-24.5
       parent: 1
   - uid: 313
     components:
     - type: Transform
-      pos: -1.5,-25.5
+      pos: -1.5,-24.5
       parent: 1
   - uid: 314
     components:
     - type: Transform
-      pos: -1.5,-26.5
+      pos: -1.5,-25.5
       parent: 1
   - uid: 315
     components:
     - type: Transform
-      pos: 0.5,-24.5
+      pos: -1.5,-26.5
       parent: 1
   - uid: 316
     components:
     - type: Transform
-      pos: 0.5,-25.5
+      pos: 0.5,-24.5
       parent: 1
   - uid: 317
     components:
     - type: Transform
-      pos: 0.5,-26.5
+      pos: 0.5,-25.5
       parent: 1
   - uid: 318
     components:
     - type: Transform
-      pos: 3.5,-25.5
+      pos: 0.5,-26.5
       parent: 1
   - uid: 319
     components:
     - type: Transform
-      pos: 3.5,-24.5
+      pos: 3.5,-25.5
       parent: 1
   - uid: 320
     components:
     - type: Transform
-      pos: -4.5,-25.5
+      pos: 3.5,-24.5
       parent: 1
   - uid: 321
     components:
     - type: Transform
-      pos: -4.5,-24.5
+      pos: -4.5,-25.5
       parent: 1
   - uid: 322
     components:
     - type: Transform
-      pos: -6.5,-22.5
+      pos: -4.5,-24.5
       parent: 1
   - uid: 323
     components:
     - type: Transform
-      pos: -7.5,-22.5
+      pos: -6.5,-22.5
       parent: 1
   - uid: 324
     components:
     - type: Transform
-      pos: -8.5,-22.5
+      pos: -7.5,-22.5
       parent: 1
   - uid: 325
     components:
     - type: Transform
-      pos: -9.5,-22.5
+      pos: -8.5,-22.5
       parent: 1
   - uid: 326
     components:
     - type: Transform
-      pos: -10.5,-22.5
+      pos: -9.5,-22.5
       parent: 1
   - uid: 327
     components:
     - type: Transform
-      pos: 5.5,-22.5
+      pos: -10.5,-22.5
       parent: 1
   - uid: 328
     components:
     - type: Transform
-      pos: 6.5,-22.5
+      pos: 5.5,-22.5
       parent: 1
   - uid: 329
     components:
     - type: Transform
-      pos: 7.5,-22.5
+      pos: 6.5,-22.5
       parent: 1
   - uid: 330
     components:
     - type: Transform
-      pos: 8.5,-22.5
+      pos: 7.5,-22.5
       parent: 1
   - uid: 331
+    components:
+    - type: Transform
+      pos: 8.5,-22.5
+      parent: 1
+  - uid: 332
     components:
     - type: Transform
       pos: 9.5,-22.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 332
+  - uid: 333
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
-  - uid: 333
+  - uid: 334
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
-  - uid: 334
+  - uid: 335
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-  - uid: 335
+  - uid: 336
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
-  - uid: 336
+  - uid: 337
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 337
+  - uid: 338
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 338
+  - uid: 339
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 339
+  - uid: 340
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
-  - uid: 340
+  - uid: 341
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 341
+  - uid: 342
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 342
+  - uid: 343
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 343
+  - uid: 344
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 344
+  - uid: 345
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 345
+  - uid: 346
     components:
     - type: Transform
       pos: -4.5,-19.5
       parent: 1
-  - uid: 346
+  - uid: 347
     components:
     - type: Transform
       pos: -4.5,-20.5
       parent: 1
-  - uid: 347
+  - uid: 348
     components:
     - type: Transform
       pos: 1.5,-22.5
       parent: 1
-  - uid: 348
+  - uid: 349
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 1
-  - uid: 349
+  - uid: 350
     components:
     - type: Transform
       pos: -0.5,-22.5
       parent: 1
-  - uid: 350
+  - uid: 351
     components:
     - type: Transform
       pos: -1.5,-22.5
       parent: 1
-  - uid: 351
+  - uid: 352
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
-  - uid: 352
+  - uid: 353
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
-  - uid: 353
+  - uid: 354
     components:
     - type: Transform
       pos: -4.5,-21.5
       parent: 1
-  - uid: 354
+  - uid: 355
     components:
     - type: Transform
       pos: -4.5,-22.5
       parent: 1
-  - uid: 355
+  - uid: 356
     components:
     - type: Transform
       pos: -4.5,-23.5
       parent: 1
-  - uid: 356
+  - uid: 357
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 1
-  - uid: 357
+  - uid: 358
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 1
-  - uid: 358
+  - uid: 359
     components:
     - type: Transform
       pos: -2.5,-24.5
       parent: 1
-  - uid: 359
+  - uid: 360
     components:
     - type: Transform
       pos: -1.5,-24.5
       parent: 1
-  - uid: 360
+  - uid: 361
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
-  - uid: 361
+  - uid: 362
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 1
-  - uid: 362
+  - uid: 363
     components:
     - type: Transform
       pos: 1.5,-24.5
       parent: 1
-  - uid: 363
+  - uid: 364
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 1
-  - uid: 364
+  - uid: 365
     components:
     - type: Transform
       pos: 3.5,-24.5
       parent: 1
-  - uid: 365
+  - uid: 366
     components:
     - type: Transform
       pos: 3.5,-23.5
       parent: 1
-  - uid: 366
+  - uid: 367
     components:
     - type: Transform
       pos: 3.5,-22.5
       parent: 1
-  - uid: 367
+  - uid: 368
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 1
-  - uid: 368
+  - uid: 369
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 1
-  - uid: 369
+  - uid: 370
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 1
-  - uid: 370
+  - uid: 371
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 371
+  - uid: 372
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 372
+  - uid: 373
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 373
+  - uid: 374
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
-  - uid: 374
+  - uid: 375
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-  - uid: 375
+  - uid: 376
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
-  - uid: 376
+  - uid: 377
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
-  - uid: 377
+  - uid: 378
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
-  - uid: 378
+  - uid: 379
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 1
-  - uid: 379
+  - uid: 380
     components:
     - type: Transform
       pos: 3.5,-18.5
       parent: 1
-  - uid: 380
+  - uid: 381
     components:
     - type: Transform
       pos: 3.5,-17.5
       parent: 1
-  - uid: 381
+  - uid: 382
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
-  - uid: 382
+  - uid: 383
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 383
+  - uid: 384
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
-  - uid: 384
+  - uid: 385
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 385
+  - uid: 386
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 386
+  - uid: 387
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 387
+  - uid: 388
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 388
+  - uid: 389
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 389
+  - uid: 390
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 1
-  - uid: 390
+  - uid: 391
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 391
+  - uid: 392
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
-  - uid: 392
+  - uid: 393
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
-  - uid: 393
+  - uid: 394
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 394
+  - uid: 395
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 395
+  - uid: 396
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 396
+  - uid: 397
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 397
+  - uid: 398
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 398
+  - uid: 399
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 1
-  - uid: 399
+  - uid: 400
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
-  - uid: 400
+  - uid: 401
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
-  - uid: 401
+  - uid: 402
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
-  - uid: 402
+  - uid: 403
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 403
+  - uid: 404
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 404
+  - uid: 405
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 1
-  - uid: 405
+  - uid: 406
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
-  - uid: 406
+  - uid: 407
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 1
-  - uid: 407
+  - uid: 408
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
-  - uid: 408
+  - uid: 409
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 409
+  - uid: 410
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 410
+  - uid: 411
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 411
+  - uid: 412
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 412
+  - uid: 413
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 413
+  - uid: 414
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 414
+  - uid: 415
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 415
+  - uid: 416
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 416
+  - uid: 417
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 417
+  - uid: 418
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 1
-  - uid: 418
+  - uid: 419
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 419
+  - uid: 420
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 420
+  - uid: 421
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 421
+  - uid: 422
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 422
+  - uid: 423
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 423
+  - uid: 424
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 424
+  - uid: 425
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 425
+  - uid: 426
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 426
+  - uid: 427
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 427
+  - uid: 428
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 428
+  - uid: 429
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 429
+  - uid: 430
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 430
+  - uid: 431
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 431
+  - uid: 432
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 432
+  - uid: 433
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 433
+  - uid: 434
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 434
+  - uid: 435
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 435
+  - uid: 436
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 436
+  - uid: 437
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 437
+  - uid: 438
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 438
+  - uid: 439
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 439
+  - uid: 440
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 440
+  - uid: 441
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 441
+  - uid: 442
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 442
+  - uid: 443
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 443
+  - uid: 444
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 444
+  - uid: 445
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 445
+  - uid: 446
     components:
     - type: Transform
       pos: -4.5,-18.5
       parent: 1
-  - uid: 446
+  - uid: 447
     components:
     - type: Transform
       pos: -5.5,-18.5
       parent: 1
-  - uid: 447
+  - uid: 448
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 448
+  - uid: 449
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 1
-  - uid: 449
+  - uid: 450
     components:
     - type: Transform
       pos: -2.5,-23.5
       parent: 1
-  - uid: 450
+  - uid: 451
     components:
     - type: Transform
       pos: -2.5,-24.5
       parent: 1
-  - uid: 451
+  - uid: 452
     components:
     - type: Transform
       pos: -1.5,-24.5
       parent: 1
-  - uid: 452
+  - uid: 453
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
-  - uid: 453
+  - uid: 454
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 1
-  - uid: 454
+  - uid: 455
     components:
     - type: Transform
       pos: 1.5,-24.5
       parent: 1
-  - uid: 455
+  - uid: 456
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 456
+  - uid: 457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-16.5
       parent: 1
-  - uid: 457
+  - uid: 458
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 458
+  - uid: 459
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
-  - uid: 459
+  - uid: 460
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 460
+  - uid: 461
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 461
+  - uid: 462
     components:
     - type: Transform
       pos: -9.5,-8.5
       parent: 1
-  - uid: 462
+  - uid: 463
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 1
-  - uid: 463
+  - uid: 464
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 1
-  - uid: 464
+  - uid: 465
     components:
     - type: Transform
       pos: -9.5,-9.5
       parent: 1
-  - uid: 465
+  - uid: 466
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 1
-  - uid: 466
+  - uid: 467
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 1
-  - uid: 467
+  - uid: 468
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 1
-  - uid: 468
+  - uid: 469
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 1
-  - uid: 469
+  - uid: 470
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 1
-  - uid: 470
+  - uid: 471
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 1
-  - uid: 471
+  - uid: 472
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 1
-  - uid: 472
+  - uid: 473
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
-  - uid: 473
+  - uid: 474
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 1
-  - uid: 474
+  - uid: 475
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 1
-  - uid: 475
+  - uid: 476
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
-  - uid: 476
+  - uid: 477
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 1
-  - uid: 477
+  - uid: 478
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
-  - uid: 478
+  - uid: 479
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 479
+  - uid: 480
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 480
+  - uid: 481
     components:
     - type: Transform
       pos: 9.5,-21.5
       parent: 1
-  - uid: 481
+  - uid: 482
     components:
     - type: Transform
       pos: 9.5,-22.5
       parent: 1
-  - uid: 482
+  - uid: 483
     components:
     - type: Transform
       pos: 9.5,-23.5
       parent: 1
-  - uid: 483
+  - uid: 484
     components:
     - type: Transform
       pos: 8.5,-21.5
       parent: 1
-  - uid: 484
+  - uid: 485
     components:
     - type: Transform
       pos: 8.5,-22.5
       parent: 1
-  - uid: 485
+  - uid: 486
     components:
     - type: Transform
       pos: 8.5,-23.5
       parent: 1
-  - uid: 486
+  - uid: 487
     components:
     - type: Transform
       pos: 7.5,-21.5
       parent: 1
-  - uid: 487
+  - uid: 488
     components:
     - type: Transform
       pos: 7.5,-22.5
       parent: 1
-  - uid: 488
+  - uid: 489
     components:
     - type: Transform
       pos: 7.5,-23.5
       parent: 1
-  - uid: 489
+  - uid: 490
     components:
     - type: Transform
       pos: -8.5,-23.5
       parent: 1
-  - uid: 490
+  - uid: 491
     components:
     - type: Transform
       pos: -8.5,-22.5
       parent: 1
-  - uid: 491
+  - uid: 492
     components:
     - type: Transform
       pos: -8.5,-21.5
       parent: 1
-  - uid: 492
+  - uid: 493
     components:
     - type: Transform
       pos: -9.5,-23.5
       parent: 1
-  - uid: 493
+  - uid: 494
     components:
     - type: Transform
       pos: -9.5,-22.5
       parent: 1
-  - uid: 494
+  - uid: 495
     components:
     - type: Transform
       pos: -9.5,-21.5
       parent: 1
-  - uid: 495
+  - uid: 496
     components:
     - type: Transform
       pos: -10.5,-23.5
       parent: 1
-  - uid: 496
+  - uid: 497
     components:
     - type: Transform
       pos: -10.5,-22.5
       parent: 1
-  - uid: 497
+  - uid: 498
     components:
     - type: Transform
       pos: -10.5,-21.5
       parent: 1
-  - uid: 498
+  - uid: 499
     components:
     - type: Transform
       pos: -9.5,-19.5
       parent: 1
-  - uid: 499
+  - uid: 500
     components:
     - type: Transform
       pos: -9.5,-18.5
       parent: 1
-  - uid: 500
+  - uid: 501
     components:
     - type: Transform
       pos: 8.5,-18.5
       parent: 1
-  - uid: 501
+  - uid: 502
     components:
     - type: Transform
       pos: 8.5,-19.5
       parent: 1
-  - uid: 502
+  - uid: 503
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
-  - uid: 503
+  - uid: 504
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 504
+  - uid: 505
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 505
+  - uid: 506
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
-  - uid: 506
+  - uid: 507
     components:
     - type: Transform
       pos: -2.5,-26.5
       parent: 1
-  - uid: 507
+  - uid: 508
     components:
     - type: Transform
       pos: -1.5,-26.5
       parent: 1
-  - uid: 508
+  - uid: 509
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
-  - uid: 509
+  - uid: 510
     components:
     - type: Transform
       pos: 0.5,-26.5
       parent: 1
-  - uid: 510
+  - uid: 511
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 1
-  - uid: 511
+  - uid: 512
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 512
+  - uid: 513
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 513
+  - uid: 514
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 514
+  - uid: 515
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 515
+  - uid: 516
     components:
     - type: Transform
       pos: -2.5,-23.5
       parent: 1
-  - uid: 516
+  - uid: 517
     components:
     - type: Transform
       pos: -3.5,-23.5
       parent: 1
-  - uid: 517
+  - uid: 518
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
-  - uid: 518
+  - uid: 519
     components:
     - type: Transform
       pos: 1.5,-23.5
       parent: 1
-  - uid: 519
+  - uid: 520
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 1
-  - uid: 520
+  - uid: 521
     components:
     - type: Transform
       pos: -1.5,-24.5
       parent: 1
-  - uid: 521
+  - uid: 522
     components:
     - type: Transform
       pos: -2.5,-24.5
       parent: 1
-  - uid: 522
+  - uid: 523
     components:
     - type: Transform
       pos: 2.5,-23.5
       parent: 1
-  - uid: 523
+  - uid: 524
     components:
     - type: Transform
       pos: 1.5,-24.5
       parent: 1
-  - uid: 524
+  - uid: 525
     components:
     - type: Transform
       pos: -4.5,-15.5
       parent: 1
-  - uid: 525
+  - uid: 526
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 1
-  - uid: 526
+  - uid: 527
     components:
     - type: Transform
       pos: -4.5,-25.5
       parent: 1
-  - uid: 527
+  - uid: 528
     components:
     - type: Transform
       pos: 3.5,-17.5
       parent: 1
-  - uid: 528
+  - uid: 529
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 1
-  - uid: 529
+  - uid: 530
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
-  - uid: 530
+  - uid: 531
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 531
+  - uid: 532
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 532
+  - uid: 533
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 1
-  - uid: 533
+  - uid: 534
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
-  - uid: 534
+  - uid: 535
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 1
-  - uid: 535
+  - uid: 536
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 536
+  - uid: 537
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 537
+  - uid: 538
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 538
+  - uid: 539
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 539
+  - uid: 540
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 540
+  - uid: 541
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 541
+  - uid: 542
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 542
+  - uid: 543
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 543
+  - uid: 544
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 544
+  - uid: 545
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 545
+  - uid: 546
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 546
+  - uid: 547
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 547
+  - uid: 548
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 548
+  - uid: 549
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 549
+  - uid: 550
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 550
+  - uid: 551
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 551
+  - uid: 552
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 552
+  - uid: 553
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 553
+  - uid: 554
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 554
+  - uid: 555
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 555
+  - uid: 556
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 556
+  - uid: 557
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 557
+  - uid: 558
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 558
+  - uid: 559
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 1
-  - uid: 559
+  - uid: 560
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
-  - uid: 560
+  - uid: 561
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
-  - uid: 561
+  - uid: 562
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 562
+  - uid: 563
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 563
+  - uid: 564
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 564
+  - uid: 565
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 1
-  - uid: 565
+  - uid: 566
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
-  - uid: 566
+  - uid: 567
     components:
     - type: Transform
       pos: 7.5,-11.5
       parent: 1
-  - uid: 567
+  - uid: 568
     components:
     - type: Transform
       pos: 7.5,-12.5
       parent: 1
-  - uid: 568
+  - uid: 569
     components:
     - type: Transform
       pos: -8.5,-11.5
       parent: 1
-  - uid: 569
+  - uid: 570
     components:
     - type: Transform
       pos: -8.5,-12.5
       parent: 1
-  - uid: 570
+  - uid: 571
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 571
+  - uid: 572
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 572
+  - uid: 573
     components:
     - type: Transform
       pos: -4.5,-16.5
       parent: 1
-  - uid: 573
+  - uid: 574
     components:
     - type: Transform
       pos: -4.5,-17.5
       parent: 1
-  - uid: 574
+  - uid: 575
     components:
     - type: Transform
       pos: -4.5,-18.5
       parent: 1
-  - uid: 575
+  - uid: 576
     components:
     - type: Transform
       pos: -4.5,-19.5
       parent: 1
-  - uid: 576
+  - uid: 577
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 577
+  - uid: 578
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 578
+  - uid: 579
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 579
+  - uid: 580
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 580
+  - uid: 581
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 581
+  - uid: 582
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 582
+  - uid: 583
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 583
+  - uid: 584
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 584
+  - uid: 585
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 585
+  - uid: 586
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 586
+  - uid: 587
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 587
+  - uid: 588
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 588
+  - uid: 589
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 589
+  - uid: 590
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 590
+  - uid: 591
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 591
+  - uid: 592
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 592
+  - uid: 593
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 593
+  - uid: 594
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-9.5
       parent: 1
-  - uid: 594
+  - uid: 595
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
-  - uid: 595
+  - uid: 596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4122,7 +4136,7 @@ entities:
       parent: 1
 - proto: CircularShieldBase
   entities:
-  - uid: 596
+  - uid: 597
     components:
     - type: Transform
       pos: -1.5,-18.5
@@ -4161,35 +4175,23 @@ entities:
           hard: False
           restitution: 0
           friction: 0.4
-    - type: ApcPowerReceiver
-      powerLoad: 0
 - proto: CircularShieldConsole
   entities:
-  - uid: 598
+  - uid: 599
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        596:
-        - CircularShieldConsoleSender: CircularShieldConsoleReceiver
+        597:
+        - - CircularShieldConsoleSender
+          - CircularShieldConsoleReceiver
     - type: ApcPowerReceiver
       powerLoad: 5
-- proto: ComputerRadar
-  entities:
-  - uid: 599
-    components:
-    - type: Transform
-      pos: -1.5,-8.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 5
-    - type: Battery
-      startingCharge: 0
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 600
+  - uid: 601
     components:
     - type: Transform
       pos: 0.5,-5.5
@@ -4197,10 +4199,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 601
+  - uid: 602
     components:
     - type: Transform
       pos: 1.5,-8.5
@@ -4208,35 +4209,29 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
+- proto: ComputerRadar
+  entities:
+  - uid: 600
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
 - proto: ComputerShuttle
   entities:
-  - uid: 602
+  - uid: 603
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-    - type: ShuttleConsoleLock
-      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
-    - type: DeviceLinkSource
-      linkedPorts: {}
-      lastSignals: {}
-      ports:
-      - device-button-1
-      - device-button-2
-      - device-button-3
-      - device-button-4
-      - device-button-5
-      - device-button-6
-      - device-button-7
-      - device-button-8
 - proto: ComputerWallmountStationRecords
   entities:
-  - uid: 603
+  - uid: 604
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4245,17 +4240,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
-- proto: ConstructionBox
-  entities:
-  - uid: 604
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 605
+  - uid: 606
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4263,28 +4250,28 @@ entities:
       parent: 1
 - proto: FaxMachineShipAntag
   entities:
-  - uid: 606
+  - uid: 607
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 607
+  - uid: 608
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
     - type: DeviceList
       devices:
+      - 624
       - 623
-      - 622
-      - 620
-      - 616
-      - 618
-      - 626
+      - 621
+      - 617
+      - 619
       - 627
-  - uid: 608
+      - 628
+  - uid: 609
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4292,20 +4279,20 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 617
-      - 619
       - 618
-  - uid: 609
+      - 620
+      - 619
+  - uid: 610
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
     - type: DeviceList
       devices:
-      - 620
-      - 624
       - 621
-  - uid: 610
+      - 625
+      - 622
+  - uid: 611
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4313,10 +4300,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 621
-      - 625
-      - 619
-  - uid: 611
+      - 622
+      - 626
+      - 620
+  - uid: 612
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4324,8 +4311,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 625
-  - uid: 612
+      - 626
+  - uid: 613
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4333,8 +4320,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 624
-  - uid: 613
+      - 625
+  - uid: 614
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4342,9 +4329,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
+      - 618
       - 617
-      - 616
-  - uid: 614
+  - uid: 615
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4352,8 +4339,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 622
-  - uid: 615
+      - 623
+  - uid: 616
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4361,150 +4348,150 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 622
-      - 803
-      - 815
-      - 626
+      - 623
+      - 804
+      - 816
       - 627
+      - 628
 - proto: Firelock
   entities:
-  - uid: 616
+  - uid: 617
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 607
-      - 9
-      - 613
-      - 15
-  - uid: 617
+      - 608
+      - 10
+      - 614
+      - 16
+  - uid: 618
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 608
-      - 11
-      - 613
-      - 15
-  - uid: 618
+      - 609
+      - 12
+      - 614
+      - 16
+  - uid: 619
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 607
-      - 9
       - 608
-      - 11
-  - uid: 619
+      - 10
+      - 609
+      - 12
+  - uid: 620
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 608
-      - 11
-      - 610
+      - 609
       - 12
-  - uid: 620
+      - 611
+      - 13
+  - uid: 621
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 607
-      - 9
-      - 609
-      - 13
-  - uid: 621
+      - 608
+      - 10
+      - 610
+      - 14
+  - uid: 622
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 609
-      - 13
       - 610
-      - 12
-  - uid: 622
+      - 14
+      - 611
+      - 13
+  - uid: 623
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 607
-      - 9
-      - 614
-      - 16
+      - 608
+      - 10
       - 615
       - 17
-  - uid: 623
+      - 616
+      - 18
+  - uid: 624
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 607
-      - 9
+      - 608
+      - 10
 - proto: FirelockGlass
   entities:
-  - uid: 624
+  - uid: 625
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 609
-      - 13
-      - 612
-      - 10
-  - uid: 625
+      - 610
+      - 14
+      - 613
+      - 11
+  - uid: 626
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 610
-      - 12
       - 611
-      - 14
-  - uid: 626
+      - 13
+      - 612
+      - 15
+  - uid: 627
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 607
-      - 9
-      - 615
-      - 17
-  - uid: 627
+      - 608
+      - 10
+      - 616
+      - 18
+  - uid: 628
     components:
     - type: Transform
       pos: -4.5,-20.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 607
-      - 9
-      - 615
-      - 17
+      - 608
+      - 10
+      - 616
+      - 18
 - proto: FloorDrain
   entities:
-  - uid: 628
+  - uid: 629
     components:
     - type: Transform
       pos: 0.5,-2.5
@@ -4513,7 +4500,7 @@ entities:
       fixtures: {}
 - proto: GasMixerOn
   entities:
-  - uid: 629
+  - uid: 630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4527,7 +4514,7 @@ entities:
       color: '#00AACCFF'
 - proto: GasPassiveGate
   entities:
-  - uid: 630
+  - uid: 631
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4535,26 +4522,26 @@ entities:
       parent: 1
 - proto: GasPassiveVent
   entities:
-  - uid: 631
+  - uid: 632
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 632
+  - uid: 633
     components:
     - type: Transform
       pos: 3.5,-18.5
       parent: 1
-  - uid: 633
+  - uid: 634
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 634
+  - uid: 635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4562,7 +4549,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 635
+  - uid: 636
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4570,7 +4557,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 636
+  - uid: 637
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4578,18 +4565,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 637
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
   - uid: 638
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-7.5
+      pos: 1.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -4597,18 +4576,26 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-5.5
+      pos: 1.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
   - uid: 640
     components:
     - type: Transform
-      pos: -3.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: -4.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
   - uid: 641
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 642
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4616,7 +4603,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 642
+  - uid: 643
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4624,18 +4611,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 643
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
   - uid: 644
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,0.5
+      pos: 3.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -4643,11 +4622,19 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 646
+  - uid: 647
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4655,7 +4642,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 647
+  - uid: 648
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4663,7 +4650,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 648
+  - uid: 649
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4671,7 +4658,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 649
+  - uid: 650
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4679,13 +4666,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 650
+  - uid: 651
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-18.5
       parent: 1
-  - uid: 651
+  - uid: 652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4693,28 +4680,28 @@ entities:
       parent: 1
 - proto: GasPipeFourway
   entities:
-  - uid: 652
+  - uid: 653
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 653
+  - uid: 654
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 654
+  - uid: 655
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 655
+  - uid: 656
     components:
     - type: Transform
       pos: -4.5,-11.5
@@ -4723,60 +4710,52 @@ entities:
       color: '#00AACCFF'
 - proto: GasPipeStraight
   entities:
-  - uid: 656
+  - uid: 657
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 657
+  - uid: 658
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 658
+  - uid: 659
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 659
+  - uid: 660
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 660
-    components:
-    - type: Transform
-      pos: 2.5,-13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
   - uid: 661
     components:
     - type: Transform
-      pos: 2.5,-12.5
+      pos: 2.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 662
     components:
     - type: Transform
-      pos: 3.5,-14.5
+      pos: 2.5,-12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#00AACCFF'
   - uid: 663
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-13.5
+      pos: 3.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -4784,7 +4763,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,-13.5
+      pos: 2.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -4792,7 +4771,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-13.5
+      pos: 0.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -4800,7 +4779,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-13.5
+      pos: -0.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -4808,15 +4787,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,-13.5
+      pos: 1.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
   - uid: 668
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-9.5
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -4824,11 +4803,19 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-10.5
+      pos: 4.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
   - uid: 670
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4836,33 +4823,25 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 671
+  - uid: 672
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 672
+  - uid: 673
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 673
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
   - uid: 674
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,-11.5
+      pos: -3.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -4870,7 +4849,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,-11.5
+      pos: -2.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -4878,7 +4857,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-11.5
+      pos: -1.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -4886,7 +4865,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,-11.5
+      pos: -0.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -4894,11 +4873,19 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-11.5
+      pos: 0.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 679
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 680
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4906,7 +4893,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 680
+  - uid: 681
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4914,7 +4901,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 681
+  - uid: 682
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4922,7 +4909,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 682
+  - uid: 683
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4930,7 +4917,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 683
+  - uid: 684
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4938,7 +4925,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 684
+  - uid: 685
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4946,19 +4933,11 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 685
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
   - uid: 686
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-6.5
+      pos: 3.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -4966,7 +4945,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-5.5
+      pos: 3.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -4974,7 +4953,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-4.5
+      pos: 3.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -4982,15 +4961,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-12.5
+      pos: 3.5,-4.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#00AACCFF'
   - uid: 690
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-11.5
+      pos: -3.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -4998,7 +4977,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-10.5
+      pos: -3.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5006,7 +4985,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-9.5
+      pos: -3.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5014,15 +4993,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-8.5
+      pos: -3.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
   - uid: 694
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-7.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5030,7 +5009,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-7.5
+      pos: -2.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5038,7 +5017,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-7.5
+      pos: 2.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5046,15 +5025,15 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-9.5
+      pos: 3.5,-7.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#DD0075FF'
   - uid: 698
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-9.5
+      pos: 2.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5062,7 +5041,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,-9.5
+      pos: 1.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5070,7 +5049,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-9.5
+      pos: -1.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5078,7 +5057,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,-9.5
+      pos: -2.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5086,15 +5065,15 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,-9.5
+      pos: -3.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 703
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-5.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5102,7 +5081,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-6.5
+      pos: -5.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5110,7 +5089,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-7.5
+      pos: -5.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5118,15 +5097,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-4.5
+      pos: -5.5,-7.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#00AACCFF'
   - uid: 707
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-3.5
+      pos: -4.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5134,7 +5113,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-2.5
+      pos: -4.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5142,15 +5121,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-4.5
+      pos: -4.5,-2.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#DD0075FF'
   - uid: 710
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-3.5
+      pos: -5.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5158,7 +5137,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-2.5
+      pos: -5.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5166,7 +5145,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-0.5
+      pos: -5.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5174,60 +5153,68 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 714
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 714
+  - uid: 715
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 715
+  - uid: 716
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 716
+  - uid: 717
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 717
+  - uid: 718
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 718
+  - uid: 719
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 719
+  - uid: 720
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 720
+  - uid: 721
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 721
+  - uid: 722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5235,19 +5222,11 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 722
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
   - uid: 723
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-1.5
+      pos: 3.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5255,15 +5234,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-3.5
+      pos: 3.5,-1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#00AACCFF'
   - uid: 725
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-1.5
+      pos: 4.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5271,7 +5250,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-0.5
+      pos: 4.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5279,7 +5258,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,0.5
+      pos: 4.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5287,7 +5266,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,1.5
+      pos: 4.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5295,7 +5274,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,2.5
+      pos: 4.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5303,7 +5282,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,3.5
+      pos: 4.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5311,15 +5290,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,2.5
+      pos: 4.5,3.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#DD0075FF'
   - uid: 732
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,3.5
+      pos: 2.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5327,15 +5306,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,1.5
+      pos: 2.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 734
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5343,15 +5322,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-2.5
+      pos: 4.5,-0.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#00AACCFF'
   - uid: 736
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-2.5
+      pos: 3.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5359,7 +5338,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-2.5
+      pos: 2.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5367,7 +5346,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,-2.5
+      pos: 1.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5375,7 +5354,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-2.5
+      pos: 0.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5383,15 +5362,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-0.5
+      pos: -0.5,-2.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#DD0075FF'
   - uid: 741
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-0.5
+      pos: 2.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5399,7 +5378,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,-0.5
+      pos: 1.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5407,15 +5386,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-0.5
+      pos: 0.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 744
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5423,7 +5402,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-13.5
+      pos: -4.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5431,15 +5410,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-14.5
+      pos: -4.5,-13.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#00AACCFF'
   - uid: 747
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-15.5
+      pos: -3.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5447,7 +5426,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-16.5
+      pos: -3.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5455,7 +5434,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-17.5
+      pos: -3.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5463,7 +5442,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-18.5
+      pos: -3.5,-17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5471,7 +5450,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-19.5
+      pos: -3.5,-18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5479,7 +5458,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-20.5
+      pos: -3.5,-19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5487,15 +5466,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-14.5
+      pos: -3.5,-20.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#DD0075FF'
   - uid: 754
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-15.5
+      pos: -4.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5503,7 +5482,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-16.5
+      pos: -4.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5511,7 +5490,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-17.5
+      pos: -4.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5519,7 +5498,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-18.5
+      pos: -4.5,-17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5527,7 +5506,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-19.5
+      pos: -4.5,-18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5535,22 +5514,22 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-20.5
+      pos: -4.5,-19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 760
     components:
     - type: Transform
-      pos: -4.5,-21.5
+      rot: 3.141592653589793 rad
+      pos: -4.5,-20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 761
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-23.5
+      pos: -4.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5558,7 +5537,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-23.5
+      pos: -3.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5566,7 +5545,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,-23.5
+      pos: -2.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5574,7 +5553,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,-23.5
+      pos: -1.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5582,7 +5561,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,-23.5
+      pos: -0.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5590,7 +5569,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-23.5
+      pos: 0.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5598,15 +5577,15 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-21.5
+      pos: 1.5,-23.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#00AACCFF'
   - uid: 768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,-22.5
+      pos: 2.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5614,7 +5593,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,-22.5
+      pos: 0.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5622,7 +5601,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,-22.5
+      pos: -0.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5630,17 +5609,25 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-22.5
+      pos: -1.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
   - uid: 772
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-22.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 773
+    components:
+    - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-17.5
       parent: 1
-  - uid: 773
+  - uid: 774
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5648,7 +5635,7 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 774
+  - uid: 775
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5656,7 +5643,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 775
+  - uid: 776
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5664,7 +5651,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 776
+  - uid: 777
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5672,7 +5659,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 777
+  - uid: 778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5680,7 +5667,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 778
+  - uid: 779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5688,14 +5675,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 779
+  - uid: 780
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 780
+  - uid: 781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5703,18 +5690,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 781
-    components:
-    - type: Transform
-      pos: 3.5,-13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
   - uid: 782
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-7.5
+      pos: 3.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -5722,15 +5701,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-9.5
+      pos: 4.5,-7.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#DD0075FF'
   - uid: 784
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-9.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -5738,11 +5717,19 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 786
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 786
+  - uid: 787
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5750,7 +5737,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 787
+  - uid: 788
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5758,7 +5745,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 788
+  - uid: 789
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5766,7 +5753,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 789
+  - uid: 790
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5776,13 +5763,13 @@ entities:
       color: '#00AACCFF'
 - proto: GasPort
   entities:
-  - uid: 790
+  - uid: 791
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-19.5
       parent: 1
-  - uid: 791
+  - uid: 792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5790,7 +5777,7 @@ entities:
       parent: 1
 - proto: GasPressurePumpOnMax
   entities:
-  - uid: 792
+  - uid: 793
     components:
     - type: Transform
       pos: 3.5,-17.5
@@ -5799,7 +5786,7 @@ entities:
       color: '#DD0075FF'
 - proto: GasVentPump
   entities:
-  - uid: 793
+  - uid: 794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5807,24 +5794,14 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 11
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 794
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-11.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 9
+      - 12
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 795
     components:
     - type: Transform
-      pos: 2.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-11.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
@@ -5834,29 +5811,28 @@ entities:
   - uid: 796
     components:
     - type: Transform
-      pos: -5.5,4.5
+      pos: 2.5,4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 14
+      - 11
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 797
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-1.5
+      pos: -5.5,4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 12
+      - 15
     - type: AtmosPipeColor
       color: '#00AACCFF'
   - uid: 798
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
@@ -5866,15 +5842,26 @@ entities:
   - uid: 799
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 800
+    components:
+    - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 14
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 800
+  - uid: 801
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5882,10 +5869,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 16
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 801
+  - uid: 802
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5893,10 +5880,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 16
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 802
+  - uid: 803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5904,10 +5891,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 10
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 803
+  - uid: 804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5915,22 +5902,22 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 16
-      - 615
       - 17
+      - 616
+      - 18
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 804
+  - uid: 805
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 17
+      - 18
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 805
+  - uid: 806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5938,12 +5925,12 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 17
+      - 18
     - type: AtmosPipeColor
       color: '#00AACCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 806
+  - uid: 807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5951,20 +5938,20 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 11
+      - 12
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 807
+  - uid: 808
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 10
+      - 11
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 808
+  - uid: 809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5972,10 +5959,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 16
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 809
+  - uid: 810
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5983,10 +5970,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 16
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 810
+  - uid: 811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5994,10 +5981,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 14
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 811
+  - uid: 812
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6005,10 +5992,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 14
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 812
+  - uid: 813
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6016,20 +6003,20 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 12
+      - 13
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 813
+  - uid: 814
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 14
+      - 15
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 814
+  - uid: 815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6037,10 +6024,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 10
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 815
+  - uid: 816
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6048,12 +6035,12 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 16
-      - 615
       - 17
+      - 616
+      - 18
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 816
+  - uid: 817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6061,10 +6048,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 17
+      - 18
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 817
+  - uid: 818
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6072,10 +6059,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 17
+      - 18
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 818
+  - uid: 819
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6083,238 +6070,256 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 10
     - type: AtmosPipeColor
       color: '#DD0075FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 819
+  - uid: 820
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 820
+  - uid: 821
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 821
+  - uid: 822
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 822
+  - uid: 823
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 823
+  - uid: 824
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 1
-  - uid: 824
+  - uid: 825
     components:
     - type: Transform
       pos: 0.5,-27.5
       parent: 1
-  - uid: 825
+  - uid: 826
     components:
     - type: Transform
       pos: -0.5,-27.5
       parent: 1
-  - uid: 826
+  - uid: 827
     components:
     - type: Transform
       pos: -1.5,-27.5
       parent: 1
-  - uid: 827
+  - uid: 828
     components:
     - type: Transform
       pos: -2.5,-27.5
       parent: 1
-  - uid: 828
+  - uid: 829
     components:
     - type: Transform
       pos: -3.5,-29.5
       parent: 1
-  - uid: 829
+  - uid: 830
     components:
     - type: Transform
       pos: -2.5,-29.5
       parent: 1
-  - uid: 830
+  - uid: 831
     components:
     - type: Transform
       pos: -1.5,-29.5
       parent: 1
-  - uid: 831
+  - uid: 832
     components:
     - type: Transform
       pos: -0.5,-29.5
       parent: 1
-  - uid: 832
+  - uid: 833
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 1
-  - uid: 833
+  - uid: 834
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 1
-  - uid: 834
+  - uid: 835
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 1
-  - uid: 835
+  - uid: 836
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 836
+  - uid: 837
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 837
+  - uid: 838
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 838
+  - uid: 839
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 839
+  - uid: 840
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 840
+  - uid: 841
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 841
+  - uid: 842
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 842
+  - uid: 843
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 843
+  - uid: 844
     components:
     - type: Transform
       pos: 6.5,-16.5
       parent: 1
-  - uid: 844
+  - uid: 845
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 1
-  - uid: 845
+  - uid: 846
     components:
     - type: Transform
       pos: -7.5,-15.5
       parent: 1
-  - uid: 846
+  - uid: 847
     components:
     - type: Transform
       pos: -7.5,-16.5
       parent: 1
 - proto: GunneryServerHigh
   entities:
-  - uid: 847
+  - uid: 848
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
+    - type: Battery
+      startingCharge: 0
+    - type: ApcPowerReceiver
+      powerLoad: 20
 - proto: GyroscopeSecurity
   entities:
-  - uid: 848
+  - uid: 849
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 1
-  - uid: 849
+  - uid: 850
     components:
     - type: Transform
       pos: -4.5,-25.5
       parent: 1
 - proto: KitchenAssembler
   entities:
-  - uid: 850
+  - uid: 851
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 851
+  - uid: 852
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
 - proto: LockerFreezerBase
   entities:
-  - uid: 852
+  - uid: 853
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
 - proto: LockerMedicineFilled
   entities:
-  - uid: 853
+  - uid: 854
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
 - proto: LockerSteel
   entities:
-  - uid: 854
+  - uid: 855
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
 - proto: LockerWallMaterialsFuelAmeJarFilled
   entities:
-  - uid: 855
+  - uid: 856
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 856
+  - uid: 857
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
 - proto: MedicalBed
   entities:
-  - uid: 857
+  - uid: 858
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
 - proto: NFHolopadShipAntag
   entities:
-  - uid: 858
+  - uid: 859
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
+- proto: NFMagnetBoxConstruction
+  entities:
+  - uid: 605
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: NFMagnetBoxOre
+  entities:
+  - uid: 861
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 859
+  - uid: 860
     components:
     - type: Transform
       anchored: True
@@ -6322,23 +6327,16 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-- proto: OreBox
-  entities:
-  - uid: 860
-    components:
-    - type: Transform
-      pos: -5.5,3.5
-      parent: 1
 - proto: OreProcessor
   entities:
-  - uid: 861
+  - uid: 862
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 862
+  - uid: 863
     components:
     - type: Transform
       anchored: True
@@ -6348,37 +6346,30 @@ entities:
       bodyType: Static
 - proto: PlastitaniumWindow
   entities:
-  - uid: 863
+  - uid: 864
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 864
+  - uid: 865
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 865
+  - uid: 866
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-- proto: PowerCellRecharger
-  entities:
-  - uid: 866
-    components:
-    - type: Transform
-      pos: 3.5,5.5
-      parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 867
+  - uid: 868
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-17.5
       parent: 1
-  - uid: 868
+  - uid: 869
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6386,74 +6377,74 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 869
+  - uid: 870
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 870
+  - uid: 871
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 871
+  - uid: 872
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 872
+  - uid: 873
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 873
+  - uid: 874
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 874
+  - uid: 875
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-9.5
       parent: 1
-  - uid: 875
+  - uid: 876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-  - uid: 876
+  - uid: 877
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 1
-  - uid: 877
+  - uid: 878
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 878
+  - uid: 879
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
-  - uid: 879
+  - uid: 880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-17.5
       parent: 1
-  - uid: 880
+  - uid: 881
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-22.5
       parent: 1
-  - uid: 881
+  - uid: 882
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6461,105 +6452,105 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 882
+  - uid: 883
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
-  - uid: 883
+  - uid: 884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-8.5
       parent: 1
-  - uid: 884
+  - uid: 885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-9.5
       parent: 1
-  - uid: 885
+  - uid: 886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-21.5
       parent: 1
-  - uid: 886
+  - uid: 887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-22.5
       parent: 1
-  - uid: 887
+  - uid: 888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-23.5
       parent: 1
-  - uid: 888
+  - uid: 889
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-23.5
       parent: 1
-  - uid: 889
+  - uid: 890
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-22.5
       parent: 1
-  - uid: 890
+  - uid: 891
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-21.5
       parent: 1
-  - uid: 891
+  - uid: 892
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-7.5
       parent: 1
-  - uid: 892
+  - uid: 893
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-8.5
       parent: 1
-  - uid: 893
+  - uid: 894
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-9.5
       parent: 1
-  - uid: 894
+  - uid: 895
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 895
+  - uid: 896
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 896
+  - uid: 897
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 897
+  - uid: 898
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
 - proto: SignalButtonDirectional
   entities:
-  - uid: 898
+  - uid: 899
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6567,53 +6558,53 @@ entities:
       parent: 1
 - proto: SignElectricalMed
   entities:
-  - uid: 899
+  - uid: 900
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 1
-  - uid: 900
+  - uid: 901
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
 - proto: SignSecureSmall
   entities:
-  - uid: 901
+  - uid: 902
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 902
+  - uid: 903
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
 - proto: SignSecureSmallRed
   entities:
-  - uid: 903
+  - uid: 904
     components:
     - type: Transform
       pos: -5.5,-19.5
       parent: 1
-  - uid: 904
+  - uid: 905
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 905
+  - uid: 906
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 906
+  - uid: 907
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 907
+  - uid: 908
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6621,71 +6612,71 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 908
+  - uid: 909
     components:
     - type: Transform
       pos: 1.5,-22.5
       parent: 1
-  - uid: 909
+  - uid: 910
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 910
-    components:
-    - type: Transform
-      pos: -3.5,-9.5
-      parent: 1
-- proto: SpawnPointPirate
-  entities:
   - uid: 911
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-- proto: SpawnPointPirateCaptain
+- proto: SpawnPointNFPirate
   entities:
   - uid: 912
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-- proto: SpawnPointPirateFirstMate
+- proto: SpawnPointNFPirateCaptain
   entities:
   - uid: 913
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-- proto: StructureGunRack
+- proto: SpawnPointNFPirateFirstMate
   entities:
   - uid: 914
     components:
     - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+- proto: StructureGunRack
+  entities:
+  - uid: 915
+    components:
+    - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 915
+  - uid: 916
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 916
+  - uid: 917
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-  - uid: 917
+  - uid: 918
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 918
+  - uid: 919
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6693,1057 +6684,1057 @@ entities:
       parent: 1
 - proto: SuitStorageEVAPirate
   entities:
-  - uid: 919
+  - uid: 920
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 920
+  - uid: 921
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 921
+  - uid: 922
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 922
+  - uid: 923
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 923
+  - uid: 924
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 924
+  - uid: 925
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 925
+  - uid: 926
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 926
+  - uid: 927
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
 - proto: ThrusterSecurity
   entities:
-  - uid: 927
+  - uid: 928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-26.5
       parent: 1
-  - uid: 928
+  - uid: 929
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-26.5
       parent: 1
-  - uid: 929
+  - uid: 930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-26.5
       parent: 1
-  - uid: 930
+  - uid: 931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-26.5
       parent: 1
-  - uid: 931
+  - uid: 932
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-26.5
       parent: 1
-  - uid: 932
+  - uid: 933
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-16.5
       parent: 1
-  - uid: 933
+  - uid: 934
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-15.5
       parent: 1
-  - uid: 934
+  - uid: 935
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-15.5
       parent: 1
-  - uid: 935
+  - uid: 936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-16.5
       parent: 1
-  - uid: 936
+  - uid: 937
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 937
+  - uid: 938
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 938
+  - uid: 939
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 939
+  - uid: 940
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 940
+  - uid: 941
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 941
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 1
-  - uid: 942
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 943
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 1
-  - uid: 944
-    components:
-    - type: Transform
-      pos: -7.5,-10.5
-      parent: 1
-  - uid: 945
-    components:
-    - type: Transform
-      pos: 5.5,-9.5
-      parent: 1
-  - uid: 946
-    components:
-    - type: Transform
-      pos: 6.5,-10.5
-      parent: 1
-  - uid: 947
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
-      parent: 1
-  - uid: 948
-    components:
-    - type: Transform
-      pos: -7.5,-2.5
-      parent: 1
-  - uid: 949
-    components:
-    - type: Transform
-      pos: -7.5,-4.5
-      parent: 1
-  - uid: 950
-    components:
-    - type: Transform
-      pos: 6.5,-14.5
-      parent: 1
-  - uid: 951
-    components:
-    - type: Transform
-      pos: -7.5,-3.5
-      parent: 1
-  - uid: 952
-    components:
-    - type: Transform
-      pos: -7.5,0.5
-      parent: 1
-  - uid: 953
-    components:
-    - type: Transform
-      pos: -7.5,1.5
-      parent: 1
-  - uid: 954
-    components:
-    - type: Transform
-      pos: -7.5,2.5
-      parent: 1
-  - uid: 955
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 1
-  - uid: 956
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 1
-  - uid: 957
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 958
-    components:
-    - type: Transform
-      pos: 6.5,-2.5
-      parent: 1
-  - uid: 959
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 1
-  - uid: 960
-    components:
-    - type: Transform
-      pos: 1.5,9.5
-      parent: 1
-  - uid: 961
-    components:
-    - type: Transform
-      pos: 1.5,8.5
-      parent: 1
-  - uid: 962
-    components:
-    - type: Transform
-      pos: 1.5,7.5
-      parent: 1
-  - uid: 963
-    components:
-    - type: Transform
-      pos: 1.5,6.5
-      parent: 1
-  - uid: 964
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 1
-  - uid: 965
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 966
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 967
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 968
-    components:
-    - type: Transform
-      pos: -2.5,9.5
-      parent: 1
-  - uid: 969
-    components:
-    - type: Transform
-      pos: -2.5,8.5
-      parent: 1
-  - uid: 970
-    components:
-    - type: Transform
-      pos: -2.5,7.5
-      parent: 1
-  - uid: 971
-    components:
-    - type: Transform
-      pos: -2.5,6.5
-      parent: 1
-  - uid: 972
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 1
-  - uid: 973
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 1
-  - uid: 974
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 1
-  - uid: 975
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 976
-    components:
-    - type: Transform
-      pos: 4.5,8.5
-      parent: 1
-  - uid: 977
-    components:
-    - type: Transform
-      pos: 4.5,7.5
-      parent: 1
-  - uid: 978
-    components:
-    - type: Transform
-      pos: 5.5,6.5
-      parent: 1
-  - uid: 979
-    components:
-    - type: Transform
-      pos: 5.5,5.5
-      parent: 1
-  - uid: 980
-    components:
-    - type: Transform
-      pos: 5.5,4.5
-      parent: 1
-  - uid: 981
-    components:
-    - type: Transform
-      pos: 5.5,3.5
-      parent: 1
-  - uid: 982
-    components:
-    - type: Transform
-      pos: -5.5,8.5
-      parent: 1
-  - uid: 983
-    components:
-    - type: Transform
-      pos: -5.5,7.5
-      parent: 1
-  - uid: 984
-    components:
-    - type: Transform
-      pos: -6.5,6.5
-      parent: 1
-  - uid: 985
-    components:
-    - type: Transform
-      pos: -6.5,5.5
-      parent: 1
-  - uid: 986
-    components:
-    - type: Transform
-      pos: -6.5,4.5
-      parent: 1
-  - uid: 987
-    components:
-    - type: Transform
-      pos: -6.5,3.5
-      parent: 1
-  - uid: 988
-    components:
-    - type: Transform
-      pos: -8.5,-10.5
-      parent: 1
-  - uid: 989
-    components:
-    - type: Transform
-      pos: -9.5,-10.5
-      parent: 1
-  - uid: 990
-    components:
-    - type: Transform
-      pos: -9.5,-13.5
-      parent: 1
-  - uid: 991
-    components:
-    - type: Transform
-      pos: -8.5,-13.5
-      parent: 1
-  - uid: 992
-    components:
-    - type: Transform
-      pos: -7.5,-13.5
-      parent: 1
-  - uid: 993
-    components:
-    - type: Transform
-      pos: -7.5,-14.5
-      parent: 1
-  - uid: 994
-    components:
-    - type: Transform
-      pos: 6.5,-13.5
-      parent: 1
-  - uid: 995
-    components:
-    - type: Transform
-      pos: 7.5,-13.5
-      parent: 1
-  - uid: 996
-    components:
-    - type: Transform
-      pos: 8.5,-13.5
-      parent: 1
-  - uid: 997
+  - uid: 39
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 1
-  - uid: 998
+  - uid: 942
     components:
     - type: Transform
-      pos: 8.5,-10.5
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 943
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 944
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 945
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 946
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 947
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 1
+  - uid: 948
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 949
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 950
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 951
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 1
+  - uid: 952
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 953
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 954
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 955
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 956
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 958
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 960
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 961
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 962
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 963
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 964
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 965
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 966
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 967
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 968
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 969
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 970
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 971
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 972
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 973
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 974
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 975
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 976
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 977
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 978
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 979
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 980
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 981
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 982
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 983
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 984
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 985
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 986
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 987
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 988
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 989
+    components:
+    - type: Transform
+      pos: -8.5,-10.5
+      parent: 1
+  - uid: 990
+    components:
+    - type: Transform
+      pos: -9.5,-10.5
+      parent: 1
+  - uid: 991
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 1
+  - uid: 992
+    components:
+    - type: Transform
+      pos: -8.5,-13.5
+      parent: 1
+  - uid: 993
+    components:
+    - type: Transform
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 994
+    components:
+    - type: Transform
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 995
+    components:
+    - type: Transform
+      pos: 6.5,-13.5
+      parent: 1
+  - uid: 996
+    components:
+    - type: Transform
+      pos: 7.5,-13.5
+      parent: 1
+  - uid: 997
+    components:
+    - type: Transform
+      pos: 8.5,-13.5
       parent: 1
   - uid: 999
     components:
     - type: Transform
-      pos: -4.5,6.5
+      pos: 8.5,-10.5
       parent: 1
   - uid: 1000
     components:
     - type: Transform
-      pos: -6.5,-4.5
+      pos: -4.5,6.5
       parent: 1
   - uid: 1001
     components:
     - type: Transform
-      pos: -6.5,-5.5
+      pos: -6.5,-4.5
       parent: 1
   - uid: 1002
     components:
     - type: Transform
-      pos: -6.5,-6.5
+      pos: -6.5,-5.5
       parent: 1
   - uid: 1003
     components:
     - type: Transform
-      pos: -6.5,-7.5
+      pos: -6.5,-6.5
       parent: 1
   - uid: 1004
     components:
     - type: Transform
-      pos: -6.5,-8.5
+      pos: -6.5,-7.5
       parent: 1
   - uid: 1005
     components:
     - type: Transform
-      pos: 5.5,-8.5
+      pos: -6.5,-8.5
       parent: 1
   - uid: 1006
     components:
     - type: Transform
-      pos: 5.5,-7.5
+      pos: 5.5,-8.5
       parent: 1
   - uid: 1007
     components:
     - type: Transform
-      pos: 5.5,-6.5
+      pos: 5.5,-7.5
       parent: 1
   - uid: 1008
     components:
     - type: Transform
-      pos: 5.5,-5.5
+      pos: 5.5,-6.5
       parent: 1
   - uid: 1009
     components:
     - type: Transform
-      pos: 5.5,-4.5
+      pos: 5.5,-5.5
       parent: 1
   - uid: 1010
     components:
     - type: Transform
-      pos: 4.5,-5.5
+      pos: 5.5,-4.5
       parent: 1
   - uid: 1011
     components:
     - type: Transform
-      pos: 2.5,-5.5
+      pos: 4.5,-5.5
       parent: 1
   - uid: 1012
     components:
     - type: Transform
-      pos: 2.5,2.5
+      pos: 2.5,-5.5
       parent: 1
   - uid: 1013
     components:
     - type: Transform
-      pos: 4.5,2.5
+      pos: 2.5,2.5
       parent: 1
   - uid: 1014
     components:
     - type: Transform
-      pos: 5.5,2.5
+      pos: 4.5,2.5
       parent: 1
   - uid: 1015
     components:
     - type: Transform
-      pos: -2.5,1.5
+      pos: 5.5,2.5
       parent: 1
   - uid: 1016
     components:
     - type: Transform
-      pos: -2.5,0.5
+      pos: -2.5,1.5
       parent: 1
   - uid: 1017
     components:
     - type: Transform
-      pos: -2.5,-0.5
+      pos: -2.5,0.5
       parent: 1
   - uid: 1018
     components:
     - type: Transform
-      pos: -2.5,-2.5
+      pos: -2.5,-0.5
       parent: 1
   - uid: 1019
     components:
     - type: Transform
-      pos: -2.5,-3.5
+      pos: -2.5,-2.5
       parent: 1
   - uid: 1020
     components:
     - type: Transform
-      pos: -2.5,-4.5
+      pos: -2.5,-3.5
       parent: 1
   - uid: 1021
     components:
     - type: Transform
-      pos: -6.5,2.5
+      pos: -2.5,-4.5
       parent: 1
   - uid: 1022
     components:
     - type: Transform
-      pos: -5.5,2.5
+      pos: -6.5,2.5
       parent: 1
   - uid: 1023
     components:
     - type: Transform
-      pos: -3.5,2.5
+      pos: -5.5,2.5
       parent: 1
   - uid: 1024
     components:
     - type: Transform
-      pos: 1.5,-4.5
+      pos: -3.5,2.5
       parent: 1
   - uid: 1025
     components:
     - type: Transform
-      pos: 1.5,-5.5
+      pos: 1.5,-4.5
       parent: 1
   - uid: 1026
     components:
     - type: Transform
-      pos: 0.5,2.5
+      pos: 1.5,-5.5
       parent: 1
   - uid: 1027
     components:
     - type: Transform
-      pos: -0.5,2.5
+      pos: 0.5,2.5
       parent: 1
   - uid: 1028
     components:
     - type: Transform
-      pos: -1.5,2.5
+      pos: -0.5,2.5
       parent: 1
   - uid: 1029
     components:
     - type: Transform
-      pos: 4.5,6.5
+      pos: -1.5,2.5
       parent: 1
   - uid: 1030
     components:
     - type: Transform
-      pos: 3.5,6.5
+      pos: 4.5,6.5
       parent: 1
   - uid: 1031
     components:
     - type: Transform
-      pos: 2.5,6.5
+      pos: 3.5,6.5
       parent: 1
   - uid: 1032
     components:
     - type: Transform
-      pos: -3.5,6.5
+      pos: 2.5,6.5
       parent: 1
   - uid: 1033
     components:
     - type: Transform
-      pos: 5.5,-10.5
+      pos: -3.5,6.5
       parent: 1
   - uid: 1034
     components:
     - type: Transform
-      pos: -6.5,-10.5
+      pos: 5.5,-10.5
       parent: 1
   - uid: 1035
     components:
     - type: Transform
-      pos: -2.5,-5.5
+      pos: -6.5,-10.5
       parent: 1
   - uid: 1036
     components:
     - type: Transform
-      pos: -2.5,-6.5
+      pos: -2.5,-5.5
       parent: 1
   - uid: 1037
     components:
     - type: Transform
-      pos: -2.5,-8.5
+      pos: -2.5,-6.5
       parent: 1
   - uid: 1038
     components:
     - type: Transform
-      pos: -2.5,-9.5
+      pos: -2.5,-8.5
       parent: 1
   - uid: 1039
     components:
     - type: Transform
-      pos: -2.5,-10.5
+      pos: -2.5,-9.5
       parent: 1
   - uid: 1040
     components:
     - type: Transform
-      pos: -1.5,-10.5
+      pos: -2.5,-10.5
       parent: 1
   - uid: 1041
     components:
     - type: Transform
-      pos: -0.5,-10.5
+      pos: -1.5,-10.5
       parent: 1
   - uid: 1042
     components:
     - type: Transform
-      pos: 0.5,-10.5
+      pos: -0.5,-10.5
       parent: 1
   - uid: 1043
     components:
     - type: Transform
-      pos: 1.5,-10.5
+      pos: 0.5,-10.5
       parent: 1
   - uid: 1044
     components:
     - type: Transform
-      pos: 2.5,-10.5
+      pos: 1.5,-10.5
       parent: 1
   - uid: 1045
     components:
     - type: Transform
-      pos: 2.5,-9.5
+      pos: 2.5,-10.5
       parent: 1
   - uid: 1046
     components:
     - type: Transform
-      pos: 2.5,-8.5
+      pos: 2.5,-9.5
       parent: 1
   - uid: 1047
     components:
     - type: Transform
-      pos: 2.5,-6.5
+      pos: 2.5,-8.5
       parent: 1
   - uid: 1048
     components:
     - type: Transform
-      pos: 5.5,-14.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 1049
     components:
     - type: Transform
-      pos: 4.5,-14.5
+      pos: 5.5,-14.5
       parent: 1
   - uid: 1050
     components:
     - type: Transform
-      pos: -6.5,-19.5
+      pos: 4.5,-14.5
       parent: 1
   - uid: 1051
     components:
     - type: Transform
-      pos: -5.5,-14.5
+      pos: -6.5,-19.5
       parent: 1
   - uid: 1052
     components:
     - type: Transform
-      pos: -6.5,-14.5
+      pos: -5.5,-14.5
       parent: 1
   - uid: 1053
     components:
     - type: Transform
-      pos: -5.5,-17.5
+      pos: -6.5,-14.5
       parent: 1
   - uid: 1054
     components:
     - type: Transform
-      pos: -6.5,-17.5
+      pos: -5.5,-17.5
       parent: 1
   - uid: 1055
     components:
     - type: Transform
-      pos: -7.5,-17.5
+      pos: -6.5,-17.5
       parent: 1
   - uid: 1056
     components:
     - type: Transform
-      pos: -7.5,-19.5
+      pos: -7.5,-17.5
       parent: 1
   - uid: 1057
     components:
     - type: Transform
-      pos: 6.5,-17.5
+      pos: -7.5,-19.5
       parent: 1
   - uid: 1058
     components:
     - type: Transform
-      pos: -5.5,-16.5
+      pos: 6.5,-17.5
       parent: 1
   - uid: 1059
     components:
     - type: Transform
-      pos: -5.5,-15.5
+      pos: -5.5,-16.5
       parent: 1
   - uid: 1060
     components:
     - type: Transform
-      pos: -6.5,-23.5
+      pos: -5.5,-15.5
       parent: 1
   - uid: 1061
     components:
     - type: Transform
-      pos: -6.5,-24.5
+      pos: -6.5,-23.5
       parent: 1
   - uid: 1062
     components:
     - type: Transform
-      pos: -6.5,-25.5
+      pos: -6.5,-24.5
       parent: 1
   - uid: 1063
     components:
     - type: Transform
-      pos: -6.5,-26.5
+      pos: -6.5,-25.5
       parent: 1
   - uid: 1064
     components:
     - type: Transform
-      pos: 5.5,-23.5
+      pos: -6.5,-26.5
       parent: 1
   - uid: 1065
     components:
     - type: Transform
-      pos: 5.5,-24.5
+      pos: 5.5,-23.5
       parent: 1
   - uid: 1066
     components:
     - type: Transform
-      pos: 5.5,-25.5
+      pos: 5.5,-24.5
       parent: 1
   - uid: 1067
     components:
     - type: Transform
-      pos: 5.5,-26.5
+      pos: 5.5,-25.5
       parent: 1
   - uid: 1068
     components:
     - type: Transform
-      pos: 2.5,-26.5
+      pos: 5.5,-26.5
       parent: 1
   - uid: 1069
     components:
     - type: Transform
-      pos: 2.5,-27.5
+      pos: 2.5,-26.5
       parent: 1
   - uid: 1070
     components:
     - type: Transform
-      pos: -3.5,-27.5
+      pos: 2.5,-27.5
       parent: 1
   - uid: 1071
     components:
     - type: Transform
-      pos: -3.5,-26.5
+      pos: -3.5,-27.5
       parent: 1
   - uid: 1072
     components:
     - type: Transform
-      pos: -4.5,-26.5
+      pos: -3.5,-26.5
       parent: 1
   - uid: 1073
     components:
     - type: Transform
-      pos: -5.5,-26.5
+      pos: -4.5,-26.5
       parent: 1
   - uid: 1074
     components:
     - type: Transform
-      pos: 3.5,-26.5
+      pos: -5.5,-26.5
       parent: 1
   - uid: 1075
     components:
     - type: Transform
-      pos: 4.5,-26.5
+      pos: 3.5,-26.5
       parent: 1
   - uid: 1076
     components:
     - type: Transform
-      pos: 2.5,-25.5
+      pos: 4.5,-26.5
       parent: 1
   - uid: 1077
     components:
     - type: Transform
-      pos: 1.5,-25.5
+      pos: 2.5,-25.5
       parent: 1
   - uid: 1078
     components:
     - type: Transform
-      pos: 0.5,-25.5
+      pos: 1.5,-25.5
       parent: 1
   - uid: 1079
     components:
     - type: Transform
-      pos: -0.5,-25.5
+      pos: 0.5,-25.5
       parent: 1
   - uid: 1080
     components:
     - type: Transform
-      pos: -1.5,-25.5
+      pos: -0.5,-25.5
       parent: 1
   - uid: 1081
     components:
     - type: Transform
-      pos: -2.5,-25.5
+      pos: -1.5,-25.5
       parent: 1
   - uid: 1082
     components:
     - type: Transform
-      pos: -3.5,-25.5
+      pos: -2.5,-25.5
       parent: 1
   - uid: 1083
     components:
     - type: Transform
-      pos: -5.5,6.5
+      pos: -3.5,-25.5
       parent: 1
   - uid: 1084
     components:
     - type: Transform
-      pos: -7.5,-5.5
+      pos: -5.5,6.5
       parent: 1
   - uid: 1085
     components:
     - type: Transform
-      pos: 7.5,-5.5
+      pos: -7.5,-5.5
       parent: 1
   - uid: 1086
     components:
     - type: Transform
-      pos: 7.5,-6.5
+      pos: 7.5,-5.5
       parent: 1
   - uid: 1087
     components:
     - type: Transform
-      pos: -7.5,-6.5
+      pos: 7.5,-6.5
       parent: 1
   - uid: 1088
     components:
     - type: Transform
-      pos: 6.5,-6.5
+      pos: -7.5,-6.5
       parent: 1
   - uid: 1089
     components:
     - type: Transform
-      pos: -8.5,-6.5
+      pos: 6.5,-6.5
       parent: 1
   - uid: 1090
     components:
     - type: Transform
-      pos: -8.5,-5.5
+      pos: -8.5,-6.5
       parent: 1
   - uid: 1091
     components:
     - type: Transform
-      pos: 6.5,-5.5
+      pos: -8.5,-5.5
       parent: 1
   - uid: 1092
     components:
     - type: Transform
-      pos: 6.5,-18.5
+      pos: 6.5,-5.5
       parent: 1
   - uid: 1093
     components:
     - type: Transform
-      pos: -7.5,-18.5
+      pos: 6.5,-18.5
       parent: 1
   - uid: 1094
     components:
     - type: Transform
-      pos: 6.5,-19.5
+      pos: -7.5,-18.5
       parent: 1
   - uid: 1095
     components:
     - type: Transform
-      pos: 5.5,-22.5
+      pos: 6.5,-19.5
       parent: 1
   - uid: 1096
     components:
     - type: Transform
-      pos: 5.5,-21.5
+      pos: 5.5,-22.5
       parent: 1
   - uid: 1097
     components:
     - type: Transform
-      pos: 5.5,-20.5
+      pos: 5.5,-21.5
       parent: 1
   - uid: 1098
     components:
     - type: Transform
-      pos: 5.5,-19.5
+      pos: 5.5,-20.5
       parent: 1
   - uid: 1099
     components:
     - type: Transform
-      pos: -6.5,-20.5
+      pos: 5.5,-19.5
       parent: 1
   - uid: 1100
     components:
     - type: Transform
-      pos: -6.5,-21.5
+      pos: -6.5,-20.5
       parent: 1
   - uid: 1101
     components:
     - type: Transform
-      pos: -6.5,-22.5
+      pos: -6.5,-21.5
       parent: 1
   - uid: 1102
     components:
     - type: Transform
-      pos: 4.5,-15.5
+      pos: -6.5,-22.5
       parent: 1
   - uid: 1103
     components:
     - type: Transform
-      pos: 4.5,-16.5
+      pos: 4.5,-15.5
       parent: 1
   - uid: 1104
     components:
     - type: Transform
-      pos: 4.5,-17.5
+      pos: 4.5,-16.5
       parent: 1
   - uid: 1105
     components:
     - type: Transform
-      pos: 5.5,-17.5
+      pos: 4.5,-17.5
       parent: 1
   - uid: 1106
     components:
     - type: Transform
-      pos: 2.5,-4.5
+      pos: 5.5,-17.5
       parent: 1
   - uid: 1107
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 1108
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 1108
+  - uid: 1109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 1
-  - uid: 1109
-    components:
-    - type: Transform
-      pos: -7.5,-9.5
-      parent: 1
   - uid: 1110
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,3.5
+      pos: -7.5,-9.5
       parent: 1
   - uid: 1111
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,7.5
+      pos: 6.5,3.5
       parent: 1
   - uid: 1112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,9.5
+      pos: 5.5,7.5
       parent: 1
   - uid: 1113
     components:
     - type: Transform
-      pos: -7.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
       parent: 1
   - uid: 1114
     components:
     - type: Transform
-      pos: -6.5,7.5
+      pos: -7.5,3.5
       parent: 1
   - uid: 1115
     components:
     - type: Transform
-      pos: -5.5,9.5
+      pos: -6.5,7.5
       parent: 1
   - uid: 1116
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 1117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-14.5
       parent: 1
-  - uid: 1117
+  - uid: 1118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-14.5
       parent: 1
-  - uid: 1118
+  - uid: 1119
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 1
-  - uid: 1119
+  - uid: 1120
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 1
-  - uid: 1120
+  - uid: 1121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 1
-  - uid: 1121
+  - uid: 1122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 1122
+  - uid: 1123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-4.5
       parent: 1
-  - uid: 1123
+  - uid: 1124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7751,616 +7742,623 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 1124
+  - uid: 1125
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 1125
+  - uid: 1126
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 1126
+  - uid: 1127
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 1
-  - uid: 1127
+  - uid: 1128
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 1128
+  - uid: 1129
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
-  - uid: 1129
+  - uid: 1130
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
-  - uid: 1130
+  - uid: 1131
     components:
     - type: Transform
       pos: 5.5,-18.5
       parent: 1
-  - uid: 1131
+  - uid: 1132
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 1
-  - uid: 1132
+  - uid: 1133
     components:
     - type: Transform
       pos: -1.5,-17.5
       parent: 1
-  - uid: 1133
+  - uid: 1134
     components:
     - type: Transform
       pos: 4.5,-20.5
       parent: 1
-  - uid: 1134
+  - uid: 1135
     components:
     - type: Transform
       pos: 3.5,-20.5
       parent: 1
-  - uid: 1135
+  - uid: 1136
     components:
     - type: Transform
       pos: -8.5,-18.5
       parent: 1
-  - uid: 1136
+  - uid: 1137
     components:
     - type: Transform
       pos: -8.5,-20.5
       parent: 1
-  - uid: 1137
+  - uid: 1138
     components:
     - type: Transform
       pos: -7.5,-21.5
       parent: 1
-  - uid: 1138
+  - uid: 1139
     components:
     - type: Transform
       pos: 4.5,-23.5
       parent: 1
-  - uid: 1139
+  - uid: 1140
     components:
     - type: Transform
       pos: 6.5,-22.5
       parent: 1
-  - uid: 1140
+  - uid: 1141
     components:
     - type: Transform
       pos: 6.5,-21.5
       parent: 1
-  - uid: 1141
+  - uid: 1142
     components:
     - type: Transform
       pos: 7.5,-20.5
       parent: 1
-  - uid: 1142
+  - uid: 1143
     components:
     - type: Transform
       pos: 7.5,-18.5
       parent: 1
-  - uid: 1143
+  - uid: 1144
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 1
-  - uid: 1144
+  - uid: 1145
     components:
     - type: Transform
       pos: 3.5,-28.5
       parent: 1
-  - uid: 1145
+  - uid: 1146
     components:
     - type: Transform
       pos: 3.5,-27.5
       parent: 1
-  - uid: 1146
+  - uid: 1147
     components:
     - type: Transform
       pos: 4.5,-27.5
       parent: 1
-  - uid: 1147
+  - uid: 1148
     components:
     - type: Transform
       pos: -4.5,-29.5
       parent: 1
-  - uid: 1148
+  - uid: 1149
     components:
     - type: Transform
       pos: -4.5,-28.5
       parent: 1
-  - uid: 1149
+  - uid: 1150
     components:
     - type: Transform
       pos: -4.5,-27.5
       parent: 1
-  - uid: 1150
+  - uid: 1151
     components:
     - type: Transform
       pos: -5.5,-27.5
       parent: 1
-  - uid: 1151
+  - uid: 1152
     components:
     - type: Transform
       pos: -9.5,-24.5
       parent: 1
-  - uid: 1152
+  - uid: 1153
     components:
     - type: Transform
       pos: -8.5,-24.5
       parent: 1
-  - uid: 1153
+  - uid: 1154
     components:
     - type: Transform
       pos: -7.5,-23.5
       parent: 1
-  - uid: 1154
+  - uid: 1155
     components:
     - type: Transform
       pos: -7.5,-25.5
       parent: 1
-  - uid: 1155
+  - uid: 1156
     components:
     - type: Transform
       pos: 6.5,-23.5
       parent: 1
-  - uid: 1156
+  - uid: 1157
     components:
     - type: Transform
       pos: 6.5,-24.5
       parent: 1
-  - uid: 1157
+  - uid: 1158
     components:
     - type: Transform
       pos: 6.5,-25.5
       parent: 1
-  - uid: 1158
+  - uid: 1159
     components:
     - type: Transform
       pos: 7.5,-24.5
       parent: 1
-  - uid: 1159
+  - uid: 1160
     components:
     - type: Transform
       pos: 8.5,-24.5
       parent: 1
-  - uid: 1160
+  - uid: 1161
     components:
     - type: Transform
       pos: 8.5,-20.5
       parent: 1
-  - uid: 1161
+  - uid: 1162
     components:
     - type: Transform
       pos: -9.5,-20.5
       parent: 1
-  - uid: 1162
+  - uid: 1163
     components:
     - type: Transform
       pos: 6.5,-20.5
       parent: 1
-  - uid: 1163
+  - uid: 1164
     components:
     - type: Transform
       pos: -7.5,-20.5
       parent: 1
-  - uid: 1164
+  - uid: 1165
     components:
     - type: Transform
       pos: -7.5,-24.5
       parent: 1
-  - uid: 1165
+  - uid: 1166
     components:
     - type: Transform
       pos: -5.5,-19.5
       parent: 1
-  - uid: 1166
+  - uid: 1167
     components:
     - type: Transform
       pos: -8.5,-19.5
       parent: 1
-  - uid: 1167
+  - uid: 1168
     components:
     - type: Transform
       pos: 7.5,-19.5
       parent: 1
-  - uid: 1168
+  - uid: 1169
     components:
     - type: Transform
       pos: -1.5,-19.5
       parent: 1
-  - uid: 1169
+  - uid: 1170
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 1
-  - uid: 1170
+  - uid: 1171
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 1
-  - uid: 1171
+  - uid: 1172
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 1
-  - uid: 1172
+  - uid: 1173
     components:
     - type: Transform
       pos: 0.5,-20.5
       parent: 1
-  - uid: 1173
+  - uid: 1174
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 1
-  - uid: 1174
+  - uid: 1175
     components:
     - type: Transform
       pos: -1.5,-20.5
       parent: 1
-  - uid: 1175
+  - uid: 1176
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 1
-  - uid: 1176
+  - uid: 1177
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
-  - uid: 1177
+  - uid: 1178
     components:
     - type: Transform
       pos: -2.5,-18.5
       parent: 1
-  - uid: 1178
+  - uid: 1179
     components:
     - type: Transform
       pos: -5.5,-20.5
       parent: 1
-  - uid: 1179
+  - uid: 1180
     components:
     - type: Transform
       pos: -5.5,-18.5
       parent: 1
-  - uid: 1180
+  - uid: 1181
     components:
     - type: Transform
       pos: -6.5,-18.5
       parent: 1
-  - uid: 1181
+  - uid: 1182
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 1
-  - uid: 1182
+  - uid: 1183
     components:
     - type: Transform
       pos: 4.5,-19.5
       parent: 1
-  - uid: 1183
+  - uid: 1184
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 1
-  - uid: 1184
+  - uid: 1185
     components:
     - type: Transform
       pos: -5.5,-24.5
       parent: 1
-  - uid: 1185
+  - uid: 1186
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 1
-  - uid: 1186
+  - uid: 1187
     components:
     - type: Transform
       pos: -5.5,-25.5
       parent: 1
-  - uid: 1187
+  - uid: 1188
     components:
     - type: Transform
       pos: 4.5,-24.5
       parent: 1
-  - uid: 1188
+  - uid: 1189
     components:
     - type: Transform
       pos: 4.5,-25.5
       parent: 1
-  - uid: 1189
+  - uid: 1190
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
-  - uid: 1190
+  - uid: 1191
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 1
-  - uid: 1191
+  - uid: 1192
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 1
-  - uid: 1192
+  - uid: 1193
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 1193
+  - uid: 1194
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 1194
+  - uid: 1195
     components:
     - type: Transform
       pos: -2.5,-15.5
       parent: 1
-  - uid: 1195
+  - uid: 1196
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 1196
+  - uid: 1197
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 1197
+  - uid: 1198
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 1198
+  - uid: 1199
     components:
     - type: Transform
       pos: 4.5,-22.5
       parent: 1
-  - uid: 1199
+  - uid: 1200
     components:
     - type: Transform
       pos: 4.5,-21.5
       parent: 1
-  - uid: 1200
+  - uid: 1201
     components:
     - type: Transform
       pos: -5.5,-21.5
       parent: 1
-  - uid: 1201
+  - uid: 1202
     components:
     - type: Transform
       pos: -5.5,-22.5
       parent: 1
-  - uid: 1202
+  - uid: 1203
     components:
     - type: Transform
       pos: -5.5,-23.5
       parent: 1
-  - uid: 1203
+  - uid: 1204
     components:
     - type: Transform
       pos: -7.5,-22.5
       parent: 1
-  - uid: 1204
+  - uid: 1205
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-  - uid: 1205
+  - uid: 1206
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 1206
+  - uid: 1207
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 1207
+  - uid: 1208
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 1208
+  - uid: 1209
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 1209
+  - uid: 1210
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
-  - uid: 1210
+  - uid: 1211
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 1211
+  - uid: 1212
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 1212
+  - uid: 1213
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 1213
+  - uid: 1214
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 1214
+  - uid: 1215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-28.5
       parent: 1
-  - uid: 1215
+  - uid: 1216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-30.5
       parent: 1
-  - uid: 1216
+  - uid: 1217
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-30.5
       parent: 1
-  - uid: 1217
+  - uid: 1218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-28.5
       parent: 1
-  - uid: 1218
+  - uid: 1219
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-26.5
       parent: 1
-  - uid: 1219
+  - uid: 1220
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-25.5
       parent: 1
-  - uid: 1220
+  - uid: 1221
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-24.5
       parent: 1
-  - uid: 1221
+  - uid: 1222
     components:
     - type: Transform
       pos: -10.5,-20.5
       parent: 1
-  - uid: 1222
+  - uid: 1223
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-24.5
       parent: 1
-  - uid: 1223
+  - uid: 1224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-25.5
       parent: 1
-  - uid: 1224
+  - uid: 1225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-26.5
       parent: 1
-  - uid: 1225
+  - uid: 1226
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-23.5
       parent: 1
-  - uid: 1226
+  - uid: 1227
     components:
     - type: Transform
       pos: -8.5,-17.5
       parent: 1
-  - uid: 1227
+  - uid: 1228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-20.5
       parent: 1
-  - uid: 1228
-    components:
-    - type: Transform
-      pos: -8.5,-23.5
-      parent: 1
   - uid: 1229
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-19.5
+      pos: -8.5,-23.5
       parent: 1
   - uid: 1230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,-17.5
+      pos: 8.5,-19.5
       parent: 1
   - uid: 1231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-17.5
+      parent: 1
+  - uid: 1232
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-21.5
       parent: 1
-  - uid: 1232
+  - uid: 1233
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-21.5
       parent: 1
-  - uid: 1233
+  - uid: 1234
     components:
     - type: Transform
       pos: -9.5,-19.5
       parent: 1
 - proto: WarpPointAdmin
   entities:
-  - uid: 1234
+  - uid: 1235
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
 - proto: WaterCooler
   entities:
-  - uid: 1235
+  - uid: 1236
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
 - proto: WaterTankFull
   entities:
-  - uid: 1236
+  - uid: 1237
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 867
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
 - proto: WeaponTurretAK570
   entities:
-  - uid: 1237
+  - uid: 1238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-18.5
       parent: 1
-  - uid: 1238
+  - uid: 1239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-3.5
       parent: 1
-  - uid: 1239
+  - uid: 1240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-3.5
       parent: 1
-  - uid: 1240
+  - uid: 1241
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8368,25 +8366,25 @@ entities:
       parent: 1
 - proto: WeaponTurretCyrexa
   entities:
-  - uid: 1241
+  - uid: 1242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-8.5
       parent: 1
-  - uid: 1242
+  - uid: 1243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-8.5
       parent: 1
-  - uid: 1243
+  - uid: 1244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-22.5
       parent: 1
-  - uid: 1244
+  - uid: 1245
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8394,7 +8392,7 @@ entities:
       parent: 1
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 1245
+  - uid: 1246
     components:
     - type: Transform
       pos: 5.5,-2.5

--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/spyglass.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/spyglass.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 06/14/2025 17:24:06
+  time: 06/29/2025 02:09:29
   entityCount: 553
 maps: []
 grids:
@@ -75,6 +75,7 @@ entities:
       id: Spyglass
     - type: OccluderTree
     - type: Shuttle
+      dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -609,9 +610,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 220
-      - 289
-      - 284
+      - 221
+      - 290
+      - 285
   - uid: 3
     components:
     - type: Transform
@@ -619,10 +620,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
+      - 222
       - 221
-      - 220
-      - 290
-      - 285
+      - 291
+      - 286
   - uid: 4
     components:
     - type: Transform
@@ -631,11 +632,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 221
       - 222
       - 223
-      - 291
-      - 287
+      - 224
+      - 292
+      - 288
   - uid: 5
     components:
     - type: Transform
@@ -643,9 +644,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 223
-      - 286
-      - 292
+      - 224
+      - 287
+      - 293
   - uid: 6
     components:
     - type: Transform
@@ -654,9 +655,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 222
-      - 293
-      - 288
+      - 223
+      - 294
+      - 289
 - proto: AirCanister
   entities:
   - uid: 7
@@ -667,7 +668,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-- proto: AirlockExternalGlassRogueLocked
+- proto: AirlockExternalGlassPirateLocked
   entities:
   - uid: 8
     components:
@@ -684,7 +685,24 @@ entities:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-- proto: AirlockHatchRogueLocked
+- proto: AirlockGlassShuttleSyndicate
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+- proto: AirlockHatchPirateLocked
   entities:
   - uid: 11
     components:
@@ -705,23 +723,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,3.5
-      parent: 1
-- proto: AirlockShuttleSyndicateRogueLocked
-  entities:
-  - uid: 15
-    components:
-    - type: Transform
-      pos: 0.5,-9.5
-      parent: 1
-  - uid: 16
-    components:
-    - type: Transform
-      pos: -0.5,-9.5
-      parent: 1
-  - uid: 17
-    components:
-    - type: Transform
-      pos: -1.5,-9.5
       parent: 1
 - proto: APCBasic
   entities:
@@ -1359,143 +1360,143 @@ entities:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 553
+  - uid: 141
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 141
+  - uid: 142
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 142
+  - uid: 143
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 143
+  - uid: 144
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 144
+  - uid: 145
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 145
+  - uid: 146
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 146
+  - uid: 147
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 147
+  - uid: 148
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 148
+  - uid: 149
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 149
+  - uid: 150
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 150
+  - uid: 151
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 151
+  - uid: 152
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 152
+  - uid: 153
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 153
+  - uid: 154
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 154
+  - uid: 155
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 155
+  - uid: 156
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 156
+  - uid: 157
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 157
+  - uid: 158
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 158
+  - uid: 159
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 159
+  - uid: 160
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 160
+  - uid: 161
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 161
+  - uid: 162
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 162
+  - uid: 163
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 163
+  - uid: 164
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 164
+  - uid: 165
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 165
+  - uid: 166
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 166
+  - uid: 167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1503,149 +1504,149 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 167
+  - uid: 168
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
-  - uid: 168
+  - uid: 169
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 169
+  - uid: 170
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 170
+  - uid: 171
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
-  - uid: 171
+  - uid: 172
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 172
+  - uid: 173
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 173
+  - uid: 174
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 174
+  - uid: 175
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 175
+  - uid: 176
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 176
+  - uid: 177
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 177
+  - uid: 178
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 178
+  - uid: 179
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 179
+  - uid: 180
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 180
+  - uid: 181
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 181
+  - uid: 182
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 182
+  - uid: 183
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 183
+  - uid: 184
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 184
+  - uid: 185
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 185
+  - uid: 186
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 186
+  - uid: 187
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 187
+  - uid: 188
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 188
+  - uid: 189
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 189
+  - uid: 190
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 190
+  - uid: 191
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 191
+  - uid: 192
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 192
+  - uid: 193
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 193
+  - uid: 194
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 194
+  - uid: 195
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 195
+  - uid: 196
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1653,7 +1654,7 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 196
+  - uid: 197
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1661,29 +1662,29 @@ entities:
       parent: 1
 - proto: CircuitImprinter
   entities:
-  - uid: 197
+  - uid: 198
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
 - proto: ComputerAnalysisConsole
   entities:
-  - uid: 198
+  - uid: 199
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        317:
-        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+        318:
+        - - ArtifactAnalyzerSender
+          - ArtifactAnalyzerReceiver
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 199
+  - uid: 200
     components:
     - type: Transform
       pos: 0.5,11.5
@@ -1691,10 +1692,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 200
+  - uid: 201
     components:
     - type: Transform
       pos: -1.5,11.5
@@ -1702,10 +1702,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerResearchAndDevelopment
   entities:
-  - uid: 201
+  - uid: 202
     components:
     - type: Transform
       pos: -5.5,4.5
@@ -1713,35 +1712,19 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 202
+  - uid: 203
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-    - type: ShuttleConsoleLock
-      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
-    - type: DeviceLinkSource
-      linkedPorts: {}
-      lastSignals: {}
-      ports:
-      - device-button-1
-      - device-button-2
-      - device-button-3
-      - device-button-4
-      - device-button-5
-      - device-button-6
-      - device-button-7
-      - device-button-8
 - proto: ComputerTabletopResearchAndDevelopment
   entities:
-  - uid: 203
+  - uid: 204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1750,10 +1733,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerTabletopStationRecords
   entities:
-  - uid: 204
+  - uid: 205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1762,17 +1744,16 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: CrateArtifactContainer
   entities:
-  - uid: 205
+  - uid: 206
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 206
+  - uid: 207
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1780,56 +1761,56 @@ entities:
       parent: 1
 - proto: EmergencyLight
   entities:
-  - uid: 207
+  - uid: 208
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-  - uid: 208
+  - uid: 209
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 209
+  - uid: 210
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 210
+  - uid: 211
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
 - proto: ExosuitFabricator
   entities:
-  - uid: 211
+  - uid: 212
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 212
+  - uid: 213
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 213
+  - uid: 214
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
 - proto: FaxMachineShipAntag
   entities:
-  - uid: 214
+  - uid: 215
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 215
+  - uid: 216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1837,8 +1818,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 220
-  - uid: 216
+      - 221
+  - uid: 217
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1846,9 +1827,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
+      - 222
       - 221
-      - 220
-  - uid: 217
+  - uid: 218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1856,10 +1837,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 221
       - 222
       - 223
-  - uid: 218
+      - 224
+  - uid: 219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1867,8 +1848,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 223
-  - uid: 219
+      - 224
+  - uid: 220
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1876,56 +1857,56 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 222
+      - 223
 - proto: Firelock
   entities:
-  - uid: 220
+  - uid: 221
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 216
+      - 217
       - 3
-      - 215
+      - 216
       - 2
-  - uid: 221
+  - uid: 222
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 217
+      - 218
       - 4
-      - 216
+      - 217
       - 3
-  - uid: 222
+  - uid: 223
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 217
+      - 218
       - 4
-      - 219
+      - 220
       - 6
-  - uid: 223
+  - uid: 224
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 218
+      - 219
       - 5
-      - 217
+      - 218
       - 4
 - proto: GasMixerOn
   entities:
-  - uid: 224
+  - uid: 225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1939,7 +1920,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasOutletInjector
   entities:
-  - uid: 225
+  - uid: 226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1947,7 +1928,7 @@ entities:
       parent: 1
 - proto: GasPassiveGate
   entities:
-  - uid: 226
+  - uid: 227
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1955,13 +1936,13 @@ entities:
       parent: 1
 - proto: GasPassiveVent
   entities:
-  - uid: 227
+  - uid: 228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 228
+  - uid: 229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1969,37 +1950,37 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 229
+  - uid: 230
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 230
+  - uid: 231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 231
+  - uid: 232
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 232
+  - uid: 233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 233
+  - uid: 234
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 234
+  - uid: 235
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2007,18 +1988,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 235
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 236
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
+      pos: 4.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -2026,18 +1999,26 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 0.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 238
+  - uid: 239
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 239
+  - uid: 240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2047,14 +2028,14 @@ entities:
       color: '#990000FF'
 - proto: GasPipeFourway
   entities:
-  - uid: 240
+  - uid: 241
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 241
+  - uid: 242
     components:
     - type: Transform
       pos: -0.5,4.5
@@ -2063,29 +2044,29 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 242
+  - uid: 243
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 243
+  - uid: 244
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 244
+  - uid: 245
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 245
+  - uid: 246
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 246
+  - uid: 247
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2093,39 +2074,31 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 247
+  - uid: 248
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 248
+  - uid: 249
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 249
+  - uid: 250
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 250
-    components:
-    - type: Transform
-      pos: 4.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 251
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,4.5
+      pos: 4.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -2133,7 +2106,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,4.5
+      pos: 3.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -2141,11 +2114,19 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 254
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 254
+  - uid: 255
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2153,7 +2134,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 255
+  - uid: 256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2161,39 +2142,31 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 256
-    components:
-    - type: Transform
-      pos: -0.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 257
     components:
     - type: Transform
-      pos: -0.5,2.5
+      pos: -0.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 258
     components:
     - type: Transform
-      pos: 0.5,4.5
+      pos: -0.5,2.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 259
     components:
     - type: Transform
-      pos: 0.5,2.5
+      pos: 0.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 260
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,3.5
+      pos: 0.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2201,11 +2174,19 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 262
+  - uid: 263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2213,7 +2194,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 263
+  - uid: 264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2221,7 +2202,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 264
+  - uid: 265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2229,7 +2210,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 265
+  - uid: 266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2237,7 +2218,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 266
+  - uid: 267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2245,7 +2226,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 267
+  - uid: 268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2253,7 +2234,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 268
+  - uid: 269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2261,7 +2242,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 269
+  - uid: 270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2269,7 +2250,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 270
+  - uid: 271
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2277,35 +2258,35 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 271
+  - uid: 272
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 272
+  - uid: 273
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 273
+  - uid: 274
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 274
+  - uid: 275
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 275
+  - uid: 276
     components:
     - type: Transform
       pos: -0.5,5.5
@@ -2314,14 +2295,14 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 276
+  - uid: 277
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 277
+  - uid: 278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2329,7 +2310,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 278
+  - uid: 279
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2339,24 +2320,24 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 279
+  - uid: 280
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 280
+  - uid: 281
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 281
+  - uid: 282
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 282
+  - uid: 283
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2364,7 +2345,7 @@ entities:
       parent: 1
 - proto: GasPressurePump
   entities:
-  - uid: 283
+  - uid: 284
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2372,7 +2353,7 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 284
+  - uid: 285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2383,7 +2364,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 285
+  - uid: 286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2394,7 +2375,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 286
+  - uid: 287
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2405,7 +2386,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 287
+  - uid: 288
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2416,7 +2397,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 288
+  - uid: 289
     components:
     - type: Transform
       pos: 0.5,8.5
@@ -2428,7 +2409,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 289
+  - uid: 290
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2439,7 +2420,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 290
+  - uid: 291
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2450,7 +2431,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 291
+  - uid: 292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2461,7 +2442,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 292
+  - uid: 293
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2472,7 +2453,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 293
+  - uid: 294
     components:
     - type: Transform
       pos: -1.5,8.5
@@ -2484,95 +2465,95 @@ entities:
       color: '#990000FF'
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 294
+  - uid: 295
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 295
+  - uid: 296
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 296
+  - uid: 297
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 297
+  - uid: 298
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 298
+  - uid: 299
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 299
+  - uid: 300
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 300
+  - uid: 301
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 301
+  - uid: 302
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 302
+  - uid: 303
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 303
+  - uid: 304
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 304
+  - uid: 305
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 1
-  - uid: 305
+  - uid: 306
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 306
+  - uid: 307
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 307
+  - uid: 308
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 1
-  - uid: 308
+  - uid: 309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 309
+  - uid: 310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-4.5
       parent: 1
-  - uid: 310
+  - uid: 311
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2580,7 +2561,7 @@ entities:
       parent: 1
 - proto: GunneryServerLow
   entities:
-  - uid: 311
+  - uid: 312
     components:
     - type: Transform
       pos: 4.5,-1.5
@@ -2591,7 +2572,7 @@ entities:
       powerLoad: 5
 - proto: GyroscopeSecurity
   entities:
-  - uid: 312
+  - uid: 313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2599,15 +2580,53 @@ entities:
       parent: 1
 - proto: HighSecDoor
   entities:
-  - uid: 313
+  - uid: 314
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-- proto: LockerScienceFilled
+- proto: LockerWallMaterialsFuelUraniumFilled
   entities:
-  - uid: 314
+  - uid: 317
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+- proto: MachineArtifactAnalyzer
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+- proto: MachineFTLDrive
+  entities:
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+- proto: NFBedrollFolded
+  entities:
+  - uid: 316
+    components:
+    - type: Transform
+      parent: 315
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: NFHolopadShipAntag
+  entities:
+  - uid: 320
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+- proto: NFLockerScienceFilled
+  entities:
+  - uid: 315
     components:
     - type: Transform
       pos: -3.5,4.5
@@ -2636,73 +2655,35 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 315
+          - 316
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-- proto: LockerWallMaterialsFuelUraniumFilled
-  entities:
-  - uid: 316
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,1.5
-      parent: 1
-- proto: MachineArtifactAnalyzer
-  entities:
-  - uid: 317
-    components:
-    - type: Transform
-      pos: -4.5,-0.5
-      parent: 1
-- proto: MachineFTLDrive
-  entities:
-  - uid: 318
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-- proto: NFBedrollFolded
-  entities:
-  - uid: 315
-    components:
-    - type: Transform
-      parent: 314
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: NFHolopadShipAntag
-  entities:
-  - uid: 319
-    components:
-    - type: Transform
-      pos: -0.5,7.5
-      parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 320
+  - uid: 321
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 321
+  - uid: 322
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
 - proto: PaperBin20
   entities:
-  - uid: 322
+  - uid: 323
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 323
+  - uid: 324
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2710,43 +2691,43 @@ entities:
       parent: 1
 - proto: PlastitaniumWindow
   entities:
-  - uid: 324
+  - uid: 325
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 325
+  - uid: 326
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 326
+  - uid: 327
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
 - proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 327
+  - uid: 328
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 328
+  - uid: 329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 1
-  - uid: 329
+  - uid: 330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 330
+  - uid: 331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2754,19 +2735,19 @@ entities:
       parent: 1
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 331
+  - uid: 332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 332
+  - uid: 333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 333
+  - uid: 334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2774,33 +2755,33 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 334
+  - uid: 335
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 335
+  - uid: 336
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
 - proto: Protolathe
   entities:
-  - uid: 336
+  - uid: 337
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
 - proto: Railing
   entities:
-  - uid: 337
+  - uid: 338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 1
-  - uid: 338
+  - uid: 339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2808,13 +2789,13 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 339
+  - uid: 340
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,9.5
       parent: 1
-  - uid: 340
+  - uid: 341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2822,38 +2803,38 @@ entities:
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 341
-    components:
-    - type: Transform
-      pos: 1.5,9.5
-      parent: 1
   - uid: 342
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,9.5
+      pos: 1.5,9.5
       parent: 1
   - uid: 343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,8.5
+      pos: -2.5,9.5
       parent: 1
   - uid: 344
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 345
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 345
+  - uid: 346
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
 - proto: SignalButtonDirectional
   entities:
-  - uid: 346
+  - uid: 347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2862,86 +2843,87 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         71:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
 - proto: SignDangerMed
   entities:
-  - uid: 347
+  - uid: 348
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
 - proto: SinkStemlessWater
   entities:
-  - uid: 348
+  - uid: 349
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 349
+  - uid: 350
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 350
-    components:
-    - type: Transform
-      pos: 1.5,8.5
-      parent: 1
   - uid: 351
     components:
     - type: Transform
-      pos: -2.5,8.5
+      pos: 1.5,8.5
       parent: 1
-- proto: SpawnPointPirate
-  entities:
   - uid: 352
     components:
     - type: Transform
-      pos: 1.5,8.5
+      pos: -2.5,8.5
       parent: 1
+- proto: SpawnPointNFPirate
+  entities:
   - uid: 353
     components:
     - type: Transform
-      pos: -2.5,8.5
+      pos: 1.5,8.5
       parent: 1
-- proto: SpawnPointPirateCaptain
-  entities:
   - uid: 354
     components:
     - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+- proto: SpawnPointNFPirateCaptain
+  entities:
+  - uid: 355
+    components:
+    - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 355
+  - uid: 356
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-- proto: SpawnPointPirateFirstMate
+- proto: SpawnPointNFPirateFirstMate
   entities:
-  - uid: 356
+  - uid: 357
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 357
+  - uid: 358
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
 - proto: StairStageWhite
   entities:
-  - uid: 358
+  - uid: 359
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
 - proto: StorageCanister
   entities:
-  - uid: 359
+  - uid: 360
     components:
     - type: Transform
       anchored: True
@@ -2951,20 +2933,20 @@ entities:
       bodyType: Static
 - proto: SubstationWallBasic
   entities:
-  - uid: 360
+  - uid: 361
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
 - proto: SuitStorageWallmountEVAPirate
   entities:
-  - uid: 361
+  - uid: 362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 362
+  - uid: 363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2972,91 +2954,91 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 363
+  - uid: 364
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 364
+  - uid: 365
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 365
+  - uid: 366
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 366
+  - uid: 367
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 367
+  - uid: 368
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
 - proto: ThrusterSecurity
   entities:
-  - uid: 368
+  - uid: 369
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 1
-  - uid: 369
+  - uid: 370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-4.5
       parent: 1
-  - uid: 370
+  - uid: 371
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 371
+  - uid: 372
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 372
-    components:
-    - type: Transform
-      pos: -1.5,13.5
-      parent: 1
   - uid: 373
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-4.5
+      pos: -1.5,13.5
       parent: 1
   - uid: 374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-4.5
+      pos: 3.5,-4.5
       parent: 1
   - uid: 375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-4.5
+      pos: 4.5,-4.5
       parent: 1
   - uid: 376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-4.5
+      pos: -4.5,-4.5
       parent: 1
   - uid: 377
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 378
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 1
-  - uid: 378
+  - uid: 379
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3064,863 +3046,863 @@ entities:
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 379
+  - uid: 380
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 380
+  - uid: 381
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 381
+  - uid: 382
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-  - uid: 382
+  - uid: 383
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 1
-  - uid: 383
+  - uid: 384
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 384
+  - uid: 385
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 385
+  - uid: 386
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 386
+  - uid: 387
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 387
+  - uid: 388
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 388
+  - uid: 389
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 389
+  - uid: 390
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 390
+  - uid: 391
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 391
+  - uid: 392
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 392
+  - uid: 393
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 393
+  - uid: 394
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 394
+  - uid: 395
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 395
+  - uid: 396
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 396
+  - uid: 397
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 397
+  - uid: 398
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 1
-  - uid: 398
+  - uid: 399
     components:
     - type: Transform
       pos: -8.5,1.5
       parent: 1
-  - uid: 399
+  - uid: 400
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 1
-  - uid: 400
+  - uid: 401
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
-  - uid: 401
+  - uid: 402
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 402
+  - uid: 403
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 1
-  - uid: 403
+  - uid: 404
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 404
+  - uid: 405
     components:
     - type: Transform
       pos: -7.5,-6.5
       parent: 1
-  - uid: 405
+  - uid: 406
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 406
+  - uid: 407
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 1
-  - uid: 407
+  - uid: 408
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 408
+  - uid: 409
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 409
+  - uid: 410
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 410
+  - uid: 411
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 411
+  - uid: 412
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 412
+  - uid: 413
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 413
+  - uid: 414
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 414
+  - uid: 415
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 415
+  - uid: 416
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 416
+  - uid: 417
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 417
+  - uid: 418
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 418
+  - uid: 419
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 419
+  - uid: 420
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 420
+  - uid: 421
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 421
+  - uid: 422
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 422
+  - uid: 423
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 423
+  - uid: 424
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 424
+  - uid: 425
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 425
+  - uid: 426
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 426
+  - uid: 427
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 427
+  - uid: 428
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 428
+  - uid: 429
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 429
+  - uid: 430
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 430
+  - uid: 431
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 431
+  - uid: 432
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 432
+  - uid: 433
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 433
+  - uid: 434
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 434
+  - uid: 435
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 435
+  - uid: 436
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 436
+  - uid: 437
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 437
+  - uid: 438
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 438
+  - uid: 439
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-  - uid: 439
+  - uid: 440
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 440
+  - uid: 441
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 441
+  - uid: 442
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 442
+  - uid: 443
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 443
+  - uid: 444
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 444
+  - uid: 445
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 1
-  - uid: 445
+  - uid: 446
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 1
-  - uid: 446
+  - uid: 447
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 1
-  - uid: 447
+  - uid: 448
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
-  - uid: 448
+  - uid: 449
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 449
+  - uid: 450
     components:
     - type: Transform
       pos: -6.5,4.5
       parent: 1
-  - uid: 450
+  - uid: 451
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 451
+  - uid: 452
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 452
+  - uid: 453
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 453
+  - uid: 454
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 454
+  - uid: 455
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 455
+  - uid: 456
     components:
     - type: Transform
       pos: -6.5,5.5
       parent: 1
-  - uid: 456
+  - uid: 457
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-  - uid: 457
+  - uid: 458
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 1
-  - uid: 458
+  - uid: 459
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 1
-  - uid: 459
+  - uid: 460
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 460
+  - uid: 461
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 461
+  - uid: 462
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 462
+  - uid: 463
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 463
+  - uid: 464
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 464
+  - uid: 465
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 465
+  - uid: 466
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 466
+  - uid: 467
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 467
+  - uid: 468
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 468
+  - uid: 469
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 469
+  - uid: 470
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 470
+  - uid: 471
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 471
+  - uid: 472
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 472
+  - uid: 473
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 473
+  - uid: 474
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 474
+  - uid: 475
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 475
+  - uid: 476
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 1
-  - uid: 476
+  - uid: 477
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 477
+  - uid: 478
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 478
+  - uid: 479
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 479
+  - uid: 480
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 1
-  - uid: 480
+  - uid: 481
     components:
     - type: Transform
       pos: -2.5,15.5
       parent: 1
-  - uid: 481
+  - uid: 482
     components:
     - type: Transform
       pos: -2.5,14.5
       parent: 1
-  - uid: 482
+  - uid: 483
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 1
-  - uid: 483
+  - uid: 484
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
-  - uid: 484
+  - uid: 485
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 485
+  - uid: 486
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 486
+  - uid: 487
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 487
+  - uid: 488
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 488
+  - uid: 489
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 489
+  - uid: 490
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 490
+  - uid: 491
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 491
+  - uid: 492
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 492
+  - uid: 493
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 493
+  - uid: 494
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 494
+  - uid: 495
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 495
+  - uid: 496
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 496
+  - uid: 497
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 497
+  - uid: 498
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 498
+  - uid: 499
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 499
+  - uid: 500
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 500
+  - uid: 501
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 501
+  - uid: 502
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 502
+  - uid: 503
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 503
+  - uid: 504
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 1
-  - uid: 504
+  - uid: 505
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 505
+  - uid: 506
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 506
+  - uid: 507
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 1
-  - uid: 507
+  - uid: 508
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 508
+  - uid: 509
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 509
+  - uid: 510
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 510
+  - uid: 511
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 511
+  - uid: 512
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 512
+  - uid: 513
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 513
+  - uid: 514
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 514
+  - uid: 515
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 515
+  - uid: 516
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 516
+  - uid: 517
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 517
+  - uid: 518
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 518
+  - uid: 519
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 519
+  - uid: 520
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 520
+  - uid: 521
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 521
+  - uid: 522
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 522
+  - uid: 523
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 523
+  - uid: 524
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 524
+  - uid: 525
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 525
+  - uid: 526
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 526
+  - uid: 527
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 527
+  - uid: 528
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 528
+  - uid: 529
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 529
+  - uid: 530
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 530
+  - uid: 531
     components:
     - type: Transform
       pos: -7.5,5.5
       parent: 1
-  - uid: 531
+  - uid: 532
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,5.5
       parent: 1
-  - uid: 532
+  - uid: 533
     components:
     - type: Transform
       pos: -6.5,9.5
       parent: 1
-  - uid: 533
+  - uid: 534
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 534
+  - uid: 535
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 535
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 1
   - uid: 536
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,16.5
+      pos: -2.5,16.5
       parent: 1
   - uid: 537
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,12.5
+      pos: 1.5,16.5
       parent: 1
   - uid: 538
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,9.5
+      pos: 2.5,12.5
       parent: 1
   - uid: 539
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,9.5
+      pos: 3.5,9.5
       parent: 1
   - uid: 540
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-7.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,9.5
       parent: 1
   - uid: 541
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -6.5,-9.5
+      pos: 6.5,-7.5
       parent: 1
   - uid: 542
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-9.5
+      rot: 3.141592653589793 rad
+      pos: -6.5,-9.5
       parent: 1
   - uid: 543
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -7.5,-7.5
+      pos: 5.5,-9.5
       parent: 1
   - uid: 544
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-7.5
+      parent: 1
+  - uid: 545
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 1
-  - uid: 545
+  - uid: 546
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 546
+  - uid: 547
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 1
-  - uid: 547
+  - uid: 548
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3928,7 +3910,7 @@ entities:
       parent: 1
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 548
+  - uid: 549
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3936,27 +3918,27 @@ entities:
       parent: 1
 - proto: WarpPointAdmin
   entities:
-  - uid: 549
+  - uid: 550
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 550
+  - uid: 551
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
 - proto: WeaponTurretL85Autocannon
   entities:
-  - uid: 551
+  - uid: 552
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,6.5
       parent: 1
-  - uid: 552
+  - uid: 553
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/tethys.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/tethys.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/08/2025 23:15:10
+  time: 06/29/2025 02:16:39
   entityCount: 452
 maps: []
 grids:
@@ -74,6 +74,7 @@ entities:
       id: Tethys
     - type: OccluderTree
     - type: Shuttle
+      dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -587,10 +588,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 194
-      - 443
-      - 444
-      - 240
+      - 253
+      - 200
+      - 201
+      - 248
   - uid: 3
     components:
     - type: Transform
@@ -599,10 +600,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 443
-      - 247
-      - 241
-  - uid: 5
+      - 200
+      - 255
+      - 249
+  - uid: 4
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -610,10 +611,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 185
-      - 249
-      - 244
-  - uid: 187
+      - 198
+      - 256
+      - 251
+  - uid: 5
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -621,11 +622,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 444
-      - 442
-      - 155
-      - 156
-  - uid: 441
+      - 201
+      - 199
+      - 252
+      - 247
+  - uid: 6
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -633,65 +634,65 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 185
-      - 442
-      - 243
-      - 245
-- proto: AirlockExternalGlassRogueLocked
+      - 198
+      - 199
+      - 250
+      - 254
+- proto: AirlockExternalGlassPirateLocked
   entities:
-  - uid: 146
+  - uid: 7
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-- proto: AirlockHatchRogueLocked
+- proto: AirlockGlassShuttleSyndicate
   entities:
-  - uid: 9
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+- proto: AirlockHatchPirateLocked
+  entities:
+  - uid: 8
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 10
+  - uid: 9
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 11
+  - uid: 10
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 12
+  - uid: 11
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 16
+  - uid: 12
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 197
+  - uid: 13
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 274
+  - uid: 14
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 400
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-- proto: AirlockShuttleSyndicateRogueLocked
-  entities:
   - uid: 15
     components:
     - type: Transform
-      pos: -0.5,-9.5
+      pos: 1.5,3.5
       parent: 1
 - proto: APCBasic
   entities:
@@ -709,678 +710,678 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 20
+  - uid: 19
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 22
+  - uid: 20
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 23
+  - uid: 21
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 24
+  - uid: 22
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 25
+  - uid: 23
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 26
+  - uid: 24
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 27
+  - uid: 25
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 28
+  - uid: 26
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 29
+  - uid: 27
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 30
+  - uid: 28
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 31
+  - uid: 29
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 32
+  - uid: 30
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 33
+  - uid: 31
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 34
+  - uid: 32
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 35
+  - uid: 33
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 36
+  - uid: 34
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 37
+  - uid: 35
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 38
+  - uid: 36
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 39
+  - uid: 37
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 40
+  - uid: 38
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 1
-  - uid: 41
+  - uid: 39
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 42
+  - uid: 40
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 43
+  - uid: 41
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 44
+  - uid: 42
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-  - uid: 45
+  - uid: 43
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 46
+  - uid: 44
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 47
+  - uid: 45
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 1
-  - uid: 50
+  - uid: 46
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 51
+  - uid: 47
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 52
+  - uid: 48
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 53
+  - uid: 49
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 54
+  - uid: 50
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 55
+  - uid: 51
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
-  - uid: 56
+  - uid: 52
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 57
+  - uid: 53
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 58
+  - uid: 54
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1
-  - uid: 59
+  - uid: 55
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
-  - uid: 60
+  - uid: 56
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 1
-  - uid: 61
+  - uid: 57
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 62
+  - uid: 58
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 63
+  - uid: 59
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 64
+  - uid: 60
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 65
+  - uid: 61
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 445
+  - uid: 62
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 446
+  - uid: 63
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 447
+  - uid: 64
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 448
+  - uid: 65
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 306
+  - uid: 66
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
 - proto: BedsheetBlack
   entities:
-  - uid: 435
+  - uid: 67
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
 - proto: BedsheetMedical
   entities:
-  - uid: 66
+  - uid: 68
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 67
+  - uid: 69
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 68
+  - uid: 70
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 69
+  - uid: 71
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 70
+  - uid: 72
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 71
+  - uid: 73
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 72
+  - uid: 74
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 73
+  - uid: 75
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 74
+  - uid: 76
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 75
+  - uid: 77
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 76
+  - uid: 78
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 77
+  - uid: 79
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 78
+  - uid: 80
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 79
+  - uid: 81
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 80
+  - uid: 82
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 81
+  - uid: 83
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 82
+  - uid: 84
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 83
+  - uid: 85
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 84
+  - uid: 86
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 85
+  - uid: 87
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 86
+  - uid: 88
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 87
+  - uid: 89
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 88
+  - uid: 90
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 89
+  - uid: 91
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 90
+  - uid: 92
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 91
+  - uid: 93
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 92
+  - uid: 94
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 93
+  - uid: 95
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 94
+  - uid: 96
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 95
+  - uid: 97
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 96
+  - uid: 98
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 97
+  - uid: 99
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 98
+  - uid: 100
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 99
+  - uid: 101
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 100
+  - uid: 102
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 101
+  - uid: 103
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 102
+  - uid: 104
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 103
+  - uid: 105
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 104
+  - uid: 106
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 105
+  - uid: 107
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 106
+  - uid: 108
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 107
+  - uid: 109
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 108
+  - uid: 110
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 109
+  - uid: 111
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 110
+  - uid: 112
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 111
+  - uid: 113
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 112
+  - uid: 114
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 113
+  - uid: 115
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 114
+  - uid: 116
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 115
+  - uid: 117
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 116
+  - uid: 118
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 117
+  - uid: 119
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 118
+  - uid: 120
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 119
+  - uid: 121
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 120
+  - uid: 122
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 121
+  - uid: 123
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 122
+  - uid: 124
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 123
+  - uid: 125
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 449
+  - uid: 126
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 450
+  - uid: 127
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 451
+  - uid: 128
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 452
+  - uid: 129
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 124
+  - uid: 130
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 125
+  - uid: 131
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 126
+  - uid: 132
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 127
+  - uid: 133
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 128
+  - uid: 134
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 129
+  - uid: 135
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 130
+  - uid: 136
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 131
+  - uid: 137
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 132
+  - uid: 138
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 133
+  - uid: 139
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 134
+  - uid: 140
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 135
+  - uid: 141
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 136
+  - uid: 142
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 137
+  - uid: 143
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 138
+  - uid: 144
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 139
+  - uid: 145
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 140
+  - uid: 146
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 141
+  - uid: 147
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 142
+  - uid: 148
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 143
+  - uid: 149
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 144
+  - uid: 150
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1388,189 +1389,189 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 7
+  - uid: 151
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 145
+  - uid: 152
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 147
+  - uid: 153
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 148
+  - uid: 154
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 149
+  - uid: 155
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 150
+  - uid: 156
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 151
+  - uid: 157
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 152
+  - uid: 158
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 153
+  - uid: 159
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 154
+  - uid: 160
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 157
+  - uid: 161
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 158
+  - uid: 162
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 159
+  - uid: 163
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 160
+  - uid: 164
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-  - uid: 161
+  - uid: 165
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 162
+  - uid: 166
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 163
+  - uid: 167
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 164
+  - uid: 168
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 165
+  - uid: 169
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 166
+  - uid: 170
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 167
+  - uid: 171
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 168
+  - uid: 172
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 169
+  - uid: 173
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 170
+  - uid: 174
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 171
+  - uid: 175
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
-  - uid: 172
+  - uid: 176
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 173
+  - uid: 177
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 174
+  - uid: 178
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 1
-  - uid: 175
+  - uid: 179
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 228
+  - uid: 180
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 262
+  - uid: 181
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 277
+  - uid: 182
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 278
+  - uid: 183
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 283
+  - uid: 184
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 284
+  - uid: 185
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 403
+  - uid: 186
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 176
+  - uid: 187
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1578,7 +1579,7 @@ entities:
       parent: 1
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 177
+  - uid: 188
     components:
     - type: Transform
       pos: 0.5,14.5
@@ -1586,10 +1587,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 178
+  - uid: 189
     components:
     - type: Transform
       pos: -1.5,14.5
@@ -1597,35 +1597,19 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 179
+  - uid: 190
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-    - type: ShuttleConsoleLock
-      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
-    - type: DeviceLinkSource
-      linkedPorts: {}
-      lastSignals: {}
-      ports:
-      - device-button-1
-      - device-button-2
-      - device-button-3
-      - device-button-4
-      - device-button-5
-      - device-button-6
-      - device-button-7
-      - device-button-8
 - proto: ComputerWallmountStationRecords
   entities:
-  - uid: 180
+  - uid: 191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1634,17 +1618,16 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: FaxMachineShip
   entities:
-  - uid: 436
+  - uid: 192
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 181
+  - uid: 193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1652,8 +1635,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 443
-  - uid: 182
+      - 200
+  - uid: 194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1661,9 +1644,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 443
-      - 444
-  - uid: 183
+      - 200
+      - 201
+  - uid: 195
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1671,9 +1654,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 444
-      - 442
-  - uid: 184
+      - 201
+      - 199
+  - uid: 196
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1681,67 +1664,67 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 185
-  - uid: 440
+      - 198
+  - uid: 197
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
     - type: DeviceList
       devices:
-      - 185
-      - 442
+      - 198
+      - 199
 - proto: Firelock
   entities:
-  - uid: 185
+  - uid: 198
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 184
-      - 5
-      - 441
-      - 440
-  - uid: 442
+      - 196
+      - 4
+      - 6
+      - 197
+  - uid: 199
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 440
-      - 441
-      - 183
-      - 187
-  - uid: 443
+      - 197
+      - 6
+      - 195
+      - 5
+  - uid: 200
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 181
+      - 193
       - 3
-      - 182
+      - 194
       - 2
 - proto: FirelockGlass
   entities:
-  - uid: 444
+  - uid: 201
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 183
-      - 187
-      - 182
+      - 195
+      - 5
+      - 194
       - 2
 - proto: FloorDrain
   entities:
-  - uid: 430
+  - uid: 202
     components:
     - type: Transform
       pos: -1.5,8.5
@@ -1750,7 +1733,7 @@ entities:
       fixtures: {}
 - proto: GasMixerOn
   entities:
-  - uid: 188
+  - uid: 203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1764,7 +1747,7 @@ entities:
       color: '#00AACCFF'
 - proto: GasPassiveGate
   entities:
-  - uid: 189
+  - uid: 204
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1774,20 +1757,20 @@ entities:
       color: '#DD0075FF'
 - proto: GasPassiveVent
   entities:
-  - uid: 190
+  - uid: 205
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 191
+  - uid: 206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 195
+  - uid: 207
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1797,21 +1780,21 @@ entities:
       color: '#DD0075FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 198
+  - uid: 208
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 199
+  - uid: 209
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 200
+  - uid: 210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1819,7 +1802,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 201
+  - uid: 211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1827,7 +1810,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 202
+  - uid: 212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1835,7 +1818,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 203
+  - uid: 213
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1843,7 +1826,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 204
+  - uid: 214
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1851,7 +1834,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 206
+  - uid: 215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1859,7 +1842,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 207
+  - uid: 216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1867,7 +1850,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 208
+  - uid: 217
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1875,63 +1858,63 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 210
+  - uid: 218
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 211
+  - uid: 219
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 212
+  - uid: 220
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 213
+  - uid: 221
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 218
+  - uid: 222
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 219
+  - uid: 223
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 220
+  - uid: 224
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 221
+  - uid: 225
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 222
+  - uid: 226
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1939,7 +1922,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 223
+  - uid: 227
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1947,7 +1930,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 224
+  - uid: 228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1955,7 +1938,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 225
+  - uid: 229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1963,7 +1946,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 227
+  - uid: 230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1971,7 +1954,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 229
+  - uid: 231
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1979,7 +1962,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 230
+  - uid: 232
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1987,7 +1970,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 231
+  - uid: 233
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1995,21 +1978,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 232
+  - uid: 234
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 233
+  - uid: 235
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 237
+  - uid: 236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2019,7 +2002,7 @@ entities:
       color: '#DD0075FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 196
+  - uid: 237
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2027,7 +2010,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 205
+  - uid: 238
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2035,7 +2018,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 209
+  - uid: 239
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2043,7 +2026,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 217
+  - uid: 240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2051,7 +2034,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 226
+  - uid: 241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2059,7 +2042,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 234
+  - uid: 242
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2067,7 +2050,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 235
+  - uid: 243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2075,7 +2058,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 236
+  - uid: 244
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2085,13 +2068,13 @@ entities:
       color: '#DD0075FF'
 - proto: GasPort
   entities:
-  - uid: 238
+  - uid: 245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 239
+  - uid: 246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2099,7 +2082,7 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 156
+  - uid: 247
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2107,10 +2090,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 187
+      - 5
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 240
+  - uid: 248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2121,7 +2104,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 241
+  - uid: 249
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2132,7 +2115,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 243
+  - uid: 250
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2140,22 +2123,22 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 441
+      - 6
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 244
+  - uid: 251
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 4
     - type: AtmosPipeColor
       color: '#00AACCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 155
+  - uid: 252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2163,10 +2146,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 187
+      - 5
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 194
+  - uid: 253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2177,7 +2160,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 245
+  - uid: 254
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2185,10 +2168,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 441
+      - 6
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 247
+  - uid: 255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2199,153 +2182,157 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 249
+  - uid: 256
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 4
     - type: AtmosPipeColor
       color: '#DD0075FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 250
+  - uid: 257
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 251
+  - uid: 258
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 252
+  - uid: 259
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 253
+  - uid: 260
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 254
+  - uid: 261
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 255
+  - uid: 262
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 256
+  - uid: 263
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 257
+  - uid: 264
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 258
+  - uid: 265
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 259
+  - uid: 266
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 260
+  - uid: 267
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 261
+  - uid: 268
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 1
 - proto: GunneryServerLow
   entities:
-  - uid: 264
+  - uid: 269
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
+    - type: Battery
+      startingCharge: 0
+    - type: ApcPowerReceiver
+      powerLoad: 5
 - proto: GyroscopeSecurity
   entities:
-  - uid: 263
+  - uid: 270
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
 - proto: KitchenAssembler
   entities:
-  - uid: 434
+  - uid: 271
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 433
+  - uid: 272
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
 - proto: LockerFreezerBase
   entities:
-  - uid: 271
+  - uid: 273
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
 - proto: LockerMedicineFilled
   entities:
-  - uid: 293
+  - uid: 274
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
 - proto: LockerSteel
   entities:
-  - uid: 248
+  - uid: 275
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 265
+  - uid: 276
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
 - proto: MedicalBed
   entities:
-  - uid: 267
+  - uid: 277
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
 - proto: NFHolopadShipAntag
   entities:
-  - uid: 438
+  - uid: 278
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 266
+  - uid: 279
     components:
     - type: Transform
       anchored: True
@@ -2355,7 +2342,7 @@ entities:
       bodyType: Static
 - proto: OxygenCanister
   entities:
-  - uid: 268
+  - uid: 280
     components:
     - type: Transform
       anchored: True
@@ -2365,26 +2352,26 @@ entities:
       bodyType: Static
 - proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 269
+  - uid: 281
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 4
+  - uid: 282
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,3.5
       parent: 1
-  - uid: 387
+  - uid: 283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
-  - uid: 389
+  - uid: 284
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2392,41 +2379,41 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 242
+  - uid: 285
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 246
+  - uid: 286
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 1
-  - uid: 272
+  - uid: 287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 273
+  - uid: 288
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
-  - uid: 276
+  - uid: 289
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 281
+  - uid: 290
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 439
+  - uid: 291
     components:
     - type: Transform
       pos: 0.5,6.5
@@ -2440,19 +2427,19 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 192
+  - uid: 293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 1
-  - uid: 282
+  - uid: 294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 401
+  - uid: 295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2460,7 +2447,7 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 429
+  - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2468,137 +2455,137 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 285
+  - uid: 297
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 287
+  - uid: 298
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-- proto: SpawnPointPirate
+- proto: SpawnPointNFPirate
   entities:
-  - uid: 286
+  - uid: 299
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-- proto: SpawnPointPirateCaptain
+- proto: SpawnPointNFPirateCaptain
   entities:
-  - uid: 289
+  - uid: 300
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-- proto: SpawnPointPirateFirstMate
+- proto: SpawnPointNFPirateFirstMate
   entities:
-  - uid: 291
+  - uid: 301
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
 - proto: StructureGunRack
   entities:
-  - uid: 392
+  - uid: 302
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 294
+  - uid: 303
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
 - proto: SuitStorageEVAPirate
   entities:
-  - uid: 393
+  - uid: 304
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 431
+  - uid: 305
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 432
+  - uid: 306
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 437
+  - uid: 307
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
 - proto: ThrusterSecurity
   entities:
-  - uid: 295
+  - uid: 308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 1
-  - uid: 296
+  - uid: 309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 1
-  - uid: 297
+  - uid: 310
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-  - uid: 298
+  - uid: 311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
-  - uid: 299
+  - uid: 312
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 300
+  - uid: 313
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 301
+  - uid: 314
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 302
+  - uid: 315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-3.5
       parent: 1
-  - uid: 303
+  - uid: 316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-3.5
       parent: 1
-  - uid: 304
+  - uid: 317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 305
+  - uid: 318
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2606,618 +2593,618 @@ entities:
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 186
+  - uid: 319
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 307
+  - uid: 320
     components:
     - type: Transform
       pos: -2.5,16.5
       parent: 1
-  - uid: 308
+  - uid: 321
     components:
     - type: Transform
       pos: -2.5,15.5
       parent: 1
-  - uid: 309
+  - uid: 322
     components:
     - type: Transform
       pos: -2.5,14.5
       parent: 1
-  - uid: 310
+  - uid: 323
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 1
-  - uid: 311
+  - uid: 324
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 312
+  - uid: 325
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 313
+  - uid: 326
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 314
+  - uid: 327
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 315
+  - uid: 328
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 316
+  - uid: 329
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 317
+  - uid: 330
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 318
+  - uid: 331
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 319
+  - uid: 332
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 320
+  - uid: 333
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 321
+  - uid: 334
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 322
+  - uid: 335
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 323
+  - uid: 336
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 324
+  - uid: 337
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 325
+  - uid: 338
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 326
+  - uid: 339
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 327
+  - uid: 340
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 328
+  - uid: 341
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 329
+  - uid: 342
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 330
+  - uid: 343
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 331
+  - uid: 344
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 1
-  - uid: 332
+  - uid: 345
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 1
-  - uid: 333
+  - uid: 346
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 334
+  - uid: 347
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 335
+  - uid: 348
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 336
+  - uid: 349
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 337
+  - uid: 350
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 1
-  - uid: 338
+  - uid: 351
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
-  - uid: 339
+  - uid: 352
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 340
+  - uid: 353
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 341
+  - uid: 354
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 342
+  - uid: 355
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 343
+  - uid: 356
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 344
+  - uid: 357
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 345
+  - uid: 358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,12.5
       parent: 1
-  - uid: 346
+  - uid: 359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,17.5
       parent: 1
-  - uid: 347
+  - uid: 360
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 348
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 349
+  - uid: 362
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 13
+  - uid: 363
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 14
+  - uid: 364
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 19
+  - uid: 365
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 21
+  - uid: 366
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 48
+  - uid: 367
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 49
+  - uid: 368
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 214
+  - uid: 369
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 215
+  - uid: 370
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 216
+  - uid: 371
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 270
+  - uid: 372
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 279
+  - uid: 373
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 280
+  - uid: 374
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 350
+  - uid: 375
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 351
+  - uid: 376
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 352
+  - uid: 377
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 353
+  - uid: 378
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 354
+  - uid: 379
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 357
+  - uid: 380
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 358
+  - uid: 381
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 359
+  - uid: 382
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 360
+  - uid: 383
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 361
+  - uid: 384
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 362
+  - uid: 385
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 363
+  - uid: 386
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 364
+  - uid: 387
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 365
+  - uid: 388
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 366
+  - uid: 389
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 367
+  - uid: 390
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 368
+  - uid: 391
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 369
+  - uid: 392
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 370
+  - uid: 393
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 372
+  - uid: 394
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 374
+  - uid: 395
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 375
+  - uid: 396
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 377
+  - uid: 397
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 378
+  - uid: 398
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 379
+  - uid: 399
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 380
+  - uid: 400
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 381
+  - uid: 401
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 382
+  - uid: 402
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 383
+  - uid: 403
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 384
+  - uid: 404
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 385
+  - uid: 405
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 386
+  - uid: 406
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 390
+  - uid: 407
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 391
+  - uid: 408
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 394
+  - uid: 409
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 395
+  - uid: 410
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 396
+  - uid: 411
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 397
+  - uid: 412
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 398
+  - uid: 413
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 399
+  - uid: 414
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 402
+  - uid: 415
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 404
+  - uid: 416
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 405
+  - uid: 417
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 406
+  - uid: 418
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 407
+  - uid: 419
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 408
+  - uid: 420
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 409
+  - uid: 421
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 410
+  - uid: 422
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 428
+  - uid: 423
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 371
+  - uid: 424
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-8.5
       parent: 1
-  - uid: 373
+  - uid: 425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 388
+  - uid: 426
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 411
+  - uid: 427
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 412
+  - uid: 428
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 413
+  - uid: 429
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 414
+  - uid: 430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 415
+  - uid: 431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 1
-  - uid: 416
+  - uid: 432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,3.5
       parent: 1
-  - uid: 417
+  - uid: 433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-3.5
       parent: 1
-  - uid: 418
+  - uid: 434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 1
-  - uid: 419
+  - uid: 435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-8.5
       parent: 1
-  - uid: 421
+  - uid: 436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 1
-  - uid: 422
+  - uid: 437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3225,74 +3212,74 @@ entities:
       parent: 1
 - proto: WallSolid
   entities:
-  - uid: 6
+  - uid: 438
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 8
+  - uid: 439
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 193
+  - uid: 440
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 275
+  - uid: 441
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 355
+  - uid: 442
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 356
+  - uid: 443
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 376
+  - uid: 444
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 420
+  - uid: 445
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
 - proto: WarpPointAdmin
   entities:
-  - uid: 423
+  - uid: 446
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
 - proto: WeaponTurretAK570
   entities:
-  - uid: 424
+  - uid: 447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,13.5
       parent: 1
-  - uid: 425
+  - uid: 448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 426
+  - uid: 449
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,1.5
       parent: 1
-  - uid: 427
+  - uid: 450
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3300,7 +3287,7 @@ entities:
       parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 290
+  - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3308,7 +3295,7 @@ entities:
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 288
+  - uid: 452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad

--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/vega.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/vega.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/09/2025 03:13:49
+  time: 06/29/2025 02:11:29
   entityCount: 576
 maps: []
 grids:
@@ -64,6 +64,7 @@ entities:
       id: Vega
     - type: OccluderTree
     - type: Shuttle
+      dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -584,7 +585,7 @@ entities:
     - type: RadiationGridResistance
 - proto: AirAlarm
   entities:
-  - uid: 494
+  - uid: 2
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -592,11 +593,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 492
-      - 493
-      - 469
-      - 470
-  - uid: 497
+      - 265
+      - 266
+      - 328
+      - 322
+  - uid: 3
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -604,10 +605,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 491
-      - 462
-      - 463
-  - uid: 498
+      - 264
+      - 327
+      - 321
+  - uid: 4
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -615,16 +616,16 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 492
-      - 493
-      - 490
-      - 491
-      - 488
-      - 472
-      - 471
-      - 448
-      - 449
-  - uid: 501
+      - 265
+      - 266
+      - 263
+      - 264
+      - 261
+      - 323
+      - 329
+      - 326
+      - 318
+  - uid: 5
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -632,10 +633,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 488
-      - 446
-      - 450
-  - uid: 502
+      - 261
+      - 324
+      - 319
+  - uid: 6
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -643,96 +644,96 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 490
-      - 451
-      - 447
-- proto: AirlockExternalGlassRogueLocked
+      - 263
+      - 320
+      - 325
+- proto: AirlockExternalGlassPirateLocked
   entities:
-  - uid: 25
+  - uid: 7
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 26
+  - uid: 8
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 151
+  - uid: 9
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 157
+  - uid: 10
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 158
+  - uid: 11
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-- proto: AirlockHatchRogueLocked
+- proto: AirlockGlassShuttleSyndicate
   entities:
-  - uid: 156
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 382
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 383
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 384
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 385
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 1
-  - uid: 386
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 1
-  - uid: 387
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
-- proto: AirlockShuttleSyndicateRogueLocked
-  entities:
-  - uid: 27
+  - uid: 19
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-6.5
       parent: 1
-  - uid: 98
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-7.5
-      parent: 1
-  - uid: 150
+  - uid: 20
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-5.5
       parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-7.5
+      parent: 1
+- proto: AirlockHatchPirateLocked
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
 - proto: AmeController
   entities:
-  - uid: 215
+  - uid: 22
     components:
     - type: Transform
       pos: 5.5,-7.5
@@ -744,38 +745,38 @@ entities:
         fuelSlot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 216
+          ent: 23
 - proto: AmeJar
   entities:
-  - uid: 216
+  - uid: 23
     components:
     - type: Transform
-      parent: 215
+      parent: 22
     - type: Physics
       canCollide: False
 - proto: AmeShielding
   entities:
-  - uid: 244
+  - uid: 24
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 245
+  - uid: 25
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 246
+  - uid: 26
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 247
+  - uid: 27
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 248
+  - uid: 28
     components:
     - type: Transform
       pos: 5.5,-5.5
@@ -783,34 +784,34 @@ entities:
     - type: PointLight
       radius: 2
       enabled: True
-  - uid: 249
+  - uid: 29
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 250
+  - uid: 30
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 251
+  - uid: 31
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 252
+  - uid: 32
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 398
+  - uid: 33
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 399
+  - uid: 34
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -818,25 +819,25 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 210
+  - uid: 35
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,7.5
       parent: 1
-  - uid: 212
+  - uid: 36
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-5.5
       parent: 1
-  - uid: 213
+  - uid: 37
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-6.5
       parent: 1
-  - uid: 214
+  - uid: 38
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -844,744 +845,744 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 525
+  - uid: 39
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 526
+  - uid: 40
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 527
+  - uid: 41
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 528
+  - uid: 42
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 529
+  - uid: 43
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 530
+  - uid: 44
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
-  - uid: 531
+  - uid: 45
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 532
+  - uid: 46
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 533
+  - uid: 47
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 534
+  - uid: 48
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 535
+  - uid: 49
     components:
     - type: Transform
       pos: 6.5,-12.5
       parent: 1
-  - uid: 536
+  - uid: 50
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 537
+  - uid: 51
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 538
+  - uid: 52
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 539
+  - uid: 53
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 540
+  - uid: 54
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 541
+  - uid: 55
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 542
+  - uid: 56
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 543
+  - uid: 57
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 544
+  - uid: 58
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 545
+  - uid: 59
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 546
+  - uid: 60
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 547
+  - uid: 61
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 548
+  - uid: 62
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 1
-  - uid: 549
+  - uid: 63
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 1
-  - uid: 550
+  - uid: 64
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 551
+  - uid: 65
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 552
+  - uid: 66
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 553
+  - uid: 67
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 554
+  - uid: 68
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 555
+  - uid: 69
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 556
+  - uid: 70
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 557
+  - uid: 71
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 558
+  - uid: 72
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
-  - uid: 559
+  - uid: 73
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 560
+  - uid: 74
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 561
+  - uid: 75
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 562
+  - uid: 76
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 563
+  - uid: 77
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
-  - uid: 564
+  - uid: 78
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 565
+  - uid: 79
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 566
+  - uid: 80
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 567
+  - uid: 81
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 568
+  - uid: 82
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 569
+  - uid: 83
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 570
+  - uid: 84
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 571
+  - uid: 85
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 572
+  - uid: 86
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 573
+  - uid: 87
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 574
+  - uid: 88
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 575
+  - uid: 89
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 576
+  - uid: 90
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 476
+  - uid: 91
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
 - proto: BedsheetBlack
   entities:
-  - uid: 477
+  - uid: 92
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 301
+  - uid: 93
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 302
+  - uid: 94
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 303
+  - uid: 95
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 304
+  - uid: 96
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 305
+  - uid: 97
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 306
+  - uid: 98
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 307
+  - uid: 99
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 308
+  - uid: 100
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 309
+  - uid: 101
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 310
+  - uid: 102
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 311
+  - uid: 103
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 312
+  - uid: 104
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 313
+  - uid: 105
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 314
+  - uid: 106
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 315
+  - uid: 107
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 316
+  - uid: 108
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 317
+  - uid: 109
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 318
+  - uid: 110
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 319
+  - uid: 111
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 1
-  - uid: 320
+  - uid: 112
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 321
+  - uid: 113
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 322
+  - uid: 114
     components:
     - type: Transform
       pos: -7.5,-6.5
       parent: 1
-  - uid: 323
+  - uid: 115
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 324
+  - uid: 116
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 325
+  - uid: 117
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 326
+  - uid: 118
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 327
+  - uid: 119
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 328
+  - uid: 120
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 329
+  - uid: 121
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 330
+  - uid: 122
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 331
+  - uid: 123
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 332
+  - uid: 124
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 333
+  - uid: 125
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 334
+  - uid: 126
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 335
+  - uid: 127
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 336
+  - uid: 128
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 337
+  - uid: 129
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 338
+  - uid: 130
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 339
+  - uid: 131
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 340
+  - uid: 132
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 341
+  - uid: 133
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 342
+  - uid: 134
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 343
+  - uid: 135
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 344
+  - uid: 136
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 345
+  - uid: 137
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 346
+  - uid: 138
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 347
+  - uid: 139
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 348
+  - uid: 140
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 349
+  - uid: 141
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 350
+  - uid: 142
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 351
+  - uid: 143
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 352
+  - uid: 144
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 353
+  - uid: 145
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 354
+  - uid: 146
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 355
+  - uid: 147
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 356
+  - uid: 148
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 357
+  - uid: 149
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 358
+  - uid: 150
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 359
+  - uid: 151
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 360
+  - uid: 152
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 361
+  - uid: 153
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 362
+  - uid: 154
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 363
+  - uid: 155
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 364
+  - uid: 156
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 365
+  - uid: 157
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 366
+  - uid: 158
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 367
+  - uid: 159
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 368
+  - uid: 160
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 369
+  - uid: 161
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 370
+  - uid: 162
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 371
+  - uid: 163
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 372
+  - uid: 164
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 373
+  - uid: 165
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 374
+  - uid: 166
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 375
+  - uid: 167
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 403
+  - uid: 168
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 404
+  - uid: 169
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 219
+  - uid: 170
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 220
+  - uid: 171
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 221
+  - uid: 172
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 222
+  - uid: 173
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 224
+  - uid: 174
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 225
+  - uid: 175
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 239
+  - uid: 176
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 240
+  - uid: 177
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 241
+  - uid: 178
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 242
+  - uid: 179
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 243
+  - uid: 180
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 400
+  - uid: 181
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 401
+  - uid: 182
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 402
+  - uid: 183
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 218
+  - uid: 184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1589,299 +1590,299 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 3
+  - uid: 185
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 4
+  - uid: 186
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 5
+  - uid: 187
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 6
+  - uid: 188
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 11
+  - uid: 189
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 43
+  - uid: 190
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 77
+  - uid: 191
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 78
+  - uid: 192
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 79
+  - uid: 193
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 80
+  - uid: 194
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 82
+  - uid: 195
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 83
+  - uid: 196
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 92
+  - uid: 197
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 93
+  - uid: 198
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 94
+  - uid: 199
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 96
+  - uid: 200
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 226
+  - uid: 201
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 227
+  - uid: 202
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 228
+  - uid: 203
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 229
+  - uid: 204
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 230
+  - uid: 205
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 231
+  - uid: 206
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 232
+  - uid: 207
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 233
+  - uid: 208
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 234
+  - uid: 209
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 235
+  - uid: 210
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 236
+  - uid: 211
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 254
+  - uid: 212
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 255
+  - uid: 213
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 256
+  - uid: 214
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 257
+  - uid: 215
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 258
+  - uid: 216
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 259
+  - uid: 217
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 260
+  - uid: 218
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 261
+  - uid: 219
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 262
+  - uid: 220
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 1
-  - uid: 263
+  - uid: 221
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 264
+  - uid: 222
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 265
+  - uid: 223
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 266
+  - uid: 224
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 273
+  - uid: 225
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 291
+  - uid: 226
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 292
+  - uid: 227
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 293
+  - uid: 228
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 294
+  - uid: 229
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 295
+  - uid: 230
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 296
+  - uid: 231
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 297
+  - uid: 232
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 298
+  - uid: 233
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 299
+  - uid: 234
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 300
+  - uid: 235
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 376
+  - uid: 236
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 377
+  - uid: 237
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 1
-  - uid: 378
+  - uid: 238
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 379
+  - uid: 239
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 380
+  - uid: 240
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 381
+  - uid: 241
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 516
+  - uid: 242
     components:
     - type: Transform
       pos: -0.61182797,3.108581
       parent: 1
-  - uid: 519
+  - uid: 243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1889,33 +1890,21 @@ entities:
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 412
+  - uid: 244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.1292617,1.893224
       parent: 1
-  - uid: 413
+  - uid: 245
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.7866697,1.041372
       parent: 1
-- proto: ComputerRadar
-  entities:
-  - uid: 407
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,0.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 5
-    - type: Battery
-      startingCharge: 0
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 406
+  - uid: 247
     components:
     - type: Transform
       pos: 2.5,2.5
@@ -1923,10 +1912,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 408
+  - uid: 248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1935,35 +1923,30 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
+- proto: ComputerRadar
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
 - proto: ComputerShuttle
   entities:
-  - uid: 405
+  - uid: 249
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-    - type: ShuttleConsoleLock
-      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
-    - type: DeviceLinkSource
-      linkedPorts: {}
-      lastSignals: {}
-      ports:
-      - device-button-1
-      - device-button-2
-      - device-button-3
-      - device-button-4
-      - device-button-5
-      - device-button-6
-      - device-button-7
-      - device-button-8
 - proto: ComputerTelevision
   entities:
-  - uid: 475
+  - uid: 250
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1972,10 +1955,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerWallmountStationRecords
   entities:
-  - uid: 486
+  - uid: 251
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1984,10 +1966,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 505
+  - uid: 252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1995,21 +1976,21 @@ entities:
       parent: 1
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 504
+  - uid: 253
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
 - proto: FaxMachineShipAntag
   entities:
-  - uid: 411
+  - uid: 254
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 495
+  - uid: 255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2017,9 +1998,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 492
-      - 493
-  - uid: 496
+      - 265
+      - 266
+  - uid: 256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2027,8 +2008,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 491
-  - uid: 499
+      - 264
+  - uid: 257
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2036,12 +2017,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 492
-      - 493
-      - 490
-      - 491
-      - 488
-  - uid: 500
+      - 265
+      - 266
+      - 263
+      - 264
+      - 261
+  - uid: 258
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2049,8 +2030,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 488
-  - uid: 503
+      - 261
+  - uid: 259
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2058,77 +2039,77 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 490
+      - 263
 - proto: Firelock
   entities:
-  - uid: 487
+  - uid: 260
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 488
+  - uid: 261
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 499
-      - 498
-      - 500
-      - 501
-  - uid: 489
+      - 257
+      - 4
+      - 258
+      - 5
+  - uid: 262
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 490
+  - uid: 263
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 499
-      - 498
-      - 503
-      - 502
-  - uid: 491
+      - 257
+      - 4
+      - 259
+      - 6
+  - uid: 264
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 499
-      - 498
-      - 496
-      - 497
-  - uid: 492
+      - 257
+      - 4
+      - 256
+      - 3
+  - uid: 265
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 495
-      - 494
-      - 499
-      - 498
-  - uid: 493
+      - 255
+      - 2
+      - 257
+      - 4
+  - uid: 266
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 495
-      - 494
-      - 499
-      - 498
+      - 255
+      - 2
+      - 257
+      - 4
 - proto: FloorDrain
   entities:
-  - uid: 485
+  - uid: 267
     components:
     - type: Transform
       pos: -0.5,6.5
@@ -2137,7 +2118,7 @@ entities:
       fixtures: {}
 - proto: GasMixerOnFlipped
   entities:
-  - uid: 396
+  - uid: 268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2148,7 +2129,7 @@ entities:
       inletOneConcentration: 0.79
 - proto: GasPassiveVent
   entities:
-  - uid: 445
+  - uid: 269
     components:
     - type: Transform
       pos: -5.5,-0.5
@@ -2157,20 +2138,20 @@ entities:
       color: '#DD0075FF'
 - proto: GasPipeBend
   entities:
-  - uid: 237
+  - uid: 270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 423
+  - uid: 271
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 434
+  - uid: 272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2178,7 +2159,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 443
+  - uid: 273
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2186,7 +2167,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 444
+  - uid: 274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2194,7 +2175,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 468
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2204,7 +2185,7 @@ entities:
       color: '#00AACCFF'
 - proto: GasPipeFourway
   entities:
-  - uid: 435
+  - uid: 276
     components:
     - type: Transform
       pos: 0.5,-0.5
@@ -2213,7 +2194,7 @@ entities:
       color: '#DD0075FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 416
+  - uid: 277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2221,7 +2202,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 417
+  - uid: 278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2229,28 +2210,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 420
+  - uid: 279
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 421
+  - uid: 280
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 422
+  - uid: 281
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 424
+  - uid: 282
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2258,7 +2239,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 425
+  - uid: 283
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2266,7 +2247,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 426
+  - uid: 284
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2274,7 +2255,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 427
+  - uid: 285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2282,7 +2263,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 428
+  - uid: 286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2290,7 +2271,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 429
+  - uid: 287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2298,7 +2279,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 431
+  - uid: 288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2306,7 +2287,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 432
+  - uid: 289
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2314,7 +2295,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 433
+  - uid: 290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2322,7 +2303,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 437
+  - uid: 291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2330,7 +2311,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 438
+  - uid: 292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2338,7 +2319,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 439
+  - uid: 293
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2346,7 +2327,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 440
+  - uid: 294
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2354,7 +2335,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 441
+  - uid: 295
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2362,42 +2343,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 442
+  - uid: 296
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 452
+  - uid: 297
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 456
+  - uid: 298
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 457
+  - uid: 299
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 458
+  - uid: 300
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 459
+  - uid: 301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2405,7 +2386,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 460
+  - uid: 302
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2413,7 +2394,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 461
+  - uid: 303
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2421,7 +2402,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 464
+  - uid: 304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2429,7 +2410,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 465
+  - uid: 305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2437,7 +2418,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 466
+  - uid: 306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2445,7 +2426,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 467
+  - uid: 307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2455,7 +2436,7 @@ entities:
       color: '#DD0075FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 415
+  - uid: 308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2463,7 +2444,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 418
+  - uid: 309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2471,7 +2452,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 419
+  - uid: 310
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2479,7 +2460,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 430
+  - uid: 311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2487,14 +2468,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 436
+  - uid: 312
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 453
+  - uid: 313
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2502,7 +2483,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 454
+  - uid: 314
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2510,7 +2491,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 455
+  - uid: 315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2520,29 +2501,29 @@ entities:
       color: '#00AACCFF'
 - proto: GasPort
   entities:
-  - uid: 395
+  - uid: 316
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 414
+  - uid: 317
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 449
+  - uid: 318
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 498
+      - 4
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 450
+  - uid: 319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2550,10 +2531,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 501
+      - 5
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 451
+  - uid: 320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2561,10 +2542,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 502
+      - 6
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 463
+  - uid: 321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2572,10 +2553,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 497
+      - 3
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 470
+  - uid: 322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2583,10 +2564,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 494
+      - 2
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 472
+  - uid: 323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2594,12 +2575,12 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 498
+      - 4
     - type: AtmosPipeColor
       color: '#00AACCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 446
+  - uid: 324
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2607,10 +2588,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 501
+      - 5
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 447
+  - uid: 325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2618,20 +2599,20 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 502
+      - 6
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 448
+  - uid: 326
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 498
+      - 4
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 462
+  - uid: 327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2639,10 +2620,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 497
+      - 3
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 469
+  - uid: 328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2650,10 +2631,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 494
+      - 2
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 471
+  - uid: 329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2661,140 +2642,144 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 498
+      - 4
     - type: AtmosPipeColor
       color: '#DD0075FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 390
+  - uid: 330
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 184
+  - uid: 331
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
-  - uid: 185
+  - uid: 332
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 186
+  - uid: 333
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 187
+  - uid: 334
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 188
+  - uid: 335
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 189
+  - uid: 336
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 190
+  - uid: 337
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 198
+  - uid: 338
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 201
+  - uid: 339
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 202
+  - uid: 340
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 275
+  - uid: 341
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 276
+  - uid: 342
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 277
+  - uid: 343
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 199
+  - uid: 344
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
 - proto: GunneryServerMedium
   entities:
-  - uid: 223
+  - uid: 345
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
+    - type: Battery
+      startingCharge: 0
+    - type: ApcPowerReceiver
+      powerLoad: 10
 - proto: GyroscopeSecurity
   entities:
-  - uid: 388
+  - uid: 346
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 392
+  - uid: 347
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
 - proto: KitchenAssembler
   entities:
-  - uid: 483
+  - uid: 348
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
 - proto: KitchenElectricRange
   entities:
-  - uid: 481
+  - uid: 349
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 482
+  - uid: 350
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
 - proto: LockerFreezerBase
   entities:
-  - uid: 480
+  - uid: 351
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
 - proto: LockerWallMaterialsFuelAmeJarFilled
   entities:
-  - uid: 253
+  - uid: 352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2802,21 +2787,21 @@ entities:
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 389
+  - uid: 353
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
 - proto: NFHolopadShipAntag
   entities:
-  - uid: 410
+  - uid: 354
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 474
+  - uid: 355
     components:
     - type: Transform
       anchored: True
@@ -2826,7 +2811,7 @@ entities:
       bodyType: Static
 - proto: OxygenCanister
   entities:
-  - uid: 473
+  - uid: 356
     components:
     - type: Transform
       anchored: True
@@ -2836,24 +2821,24 @@ entities:
       bodyType: Static
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 511
+  - uid: 357
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 514
+  - uid: 358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,9.5
       parent: 1
-  - uid: 517
+  - uid: 359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 518
+  - uid: 360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2861,13 +2846,13 @@ entities:
       parent: 1
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 509
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 513
+  - uid: 362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2875,18 +2860,18 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 506
+  - uid: 363
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 507
+  - uid: 364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
-  - uid: 508
+  - uid: 365
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2894,14 +2879,14 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 510
+  - uid: 366
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 512
+  - uid: 367
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2909,37 +2894,37 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 280
+  - uid: 368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-  - uid: 281
+  - uid: 369
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 1
-  - uid: 282
+  - uid: 370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 1
-  - uid: 283
+  - uid: 371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 288
+  - uid: 372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,9.5
       parent: 1
-  - uid: 397
+  - uid: 373
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2947,19 +2932,19 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 284
+  - uid: 374
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 1
-  - uid: 287
+  - uid: 375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,10.5
       parent: 1
-  - uid: 394
+  - uid: 376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2967,30 +2952,30 @@ entities:
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 285
+  - uid: 377
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,6.5
       parent: 1
-  - uid: 391
+  - uid: 378
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
 - proto: RailingRound
   entities:
-  - uid: 278
+  - uid: 379
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 279
+  - uid: 380
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 286
+  - uid: 381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2998,7 +2983,7 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 484
+  - uid: 382
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3006,150 +2991,150 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 217
+  - uid: 383
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 520
+  - uid: 384
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-- proto: SpawnPointPirate
+- proto: SpawnPointNFPirate
   entities:
-  - uid: 522
+  - uid: 385
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-- proto: SpawnPointPirateCaptain
+- proto: SpawnPointNFPirateCaptain
   entities:
-  - uid: 523
+  - uid: 386
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-- proto: SpawnPointPirateFirstMate
+- proto: SpawnPointNFPirateFirstMate
   entities:
-  - uid: 524
+  - uid: 387
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
 - proto: Stairs
   entities:
-  - uid: 289
+  - uid: 388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,4.5
       parent: 1
-  - uid: 290
+  - uid: 389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 393
+  - uid: 390
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 238
+  - uid: 391
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
 - proto: TableFolding
   entities:
-  - uid: 515
+  - uid: 392
     components:
     - type: Transform
       pos: -0.5701612,2.207643
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 409
+  - uid: 393
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 478
+  - uid: 394
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 479
+  - uid: 395
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
 - proto: ThrusterSecurity
   entities:
-  - uid: 20
+  - uid: 396
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 119
+  - uid: 397
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 121
+  - uid: 398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-11.5
       parent: 1
-  - uid: 122
+  - uid: 399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-11.5
       parent: 1
-  - uid: 123
+  - uid: 400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-11.5
       parent: 1
-  - uid: 124
+  - uid: 401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-11.5
       parent: 1
-  - uid: 125
+  - uid: 402
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-11.5
       parent: 1
-  - uid: 144
+  - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 1
-  - uid: 194
+  - uid: 404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
-  - uid: 196
+  - uid: 405
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 197
+  - uid: 406
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3157,547 +3142,547 @@ entities:
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 120
+  - uid: 407
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 2
+  - uid: 408
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 7
+  - uid: 409
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 8
+  - uid: 410
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 9
+  - uid: 411
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 10
+  - uid: 412
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 12
+  - uid: 413
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
-  - uid: 13
+  - uid: 414
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
-  - uid: 14
+  - uid: 415
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 1
-  - uid: 15
+  - uid: 416
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 21
+  - uid: 417
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 1
-  - uid: 22
+  - uid: 418
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-  - uid: 23
+  - uid: 419
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
-  - uid: 24
+  - uid: 420
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
-  - uid: 28
+  - uid: 421
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 30
+  - uid: 422
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 32
+  - uid: 423
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 33
+  - uid: 424
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 35
+  - uid: 425
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 36
+  - uid: 426
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 37
+  - uid: 427
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
-  - uid: 38
+  - uid: 428
     components:
     - type: Transform
       pos: 5.5,-10.5
       parent: 1
-  - uid: 39
+  - uid: 429
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 40
+  - uid: 430
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-  - uid: 41
+  - uid: 431
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
-  - uid: 42
+  - uid: 432
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 44
+  - uid: 433
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
-  - uid: 45
+  - uid: 434
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 46
+  - uid: 435
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 47
+  - uid: 436
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 48
+  - uid: 437
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 49
+  - uid: 438
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 50
+  - uid: 439
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 51
+  - uid: 440
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 52
+  - uid: 441
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 53
+  - uid: 442
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 54
+  - uid: 443
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 55
+  - uid: 444
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 56
+  - uid: 445
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 69
+  - uid: 446
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 70
+  - uid: 447
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 74
+  - uid: 448
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 75
+  - uid: 449
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 76
+  - uid: 450
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 84
+  - uid: 451
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 85
+  - uid: 452
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 86
+  - uid: 453
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 87
+  - uid: 454
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 88
+  - uid: 455
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 89
+  - uid: 456
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 90
+  - uid: 457
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 91
+  - uid: 458
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 104
+  - uid: 459
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 105
+  - uid: 460
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 106
+  - uid: 461
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 107
+  - uid: 462
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 108
+  - uid: 463
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 109
+  - uid: 464
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 110
+  - uid: 465
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 112
+  - uid: 466
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 113
+  - uid: 467
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 114
+  - uid: 468
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 115
+  - uid: 469
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 116
+  - uid: 470
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 117
+  - uid: 471
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 118
+  - uid: 472
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 126
+  - uid: 473
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 127
+  - uid: 474
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 128
+  - uid: 475
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 135
+  - uid: 476
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 136
+  - uid: 477
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 137
+  - uid: 478
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 138
+  - uid: 479
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 139
+  - uid: 480
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 140
+  - uid: 481
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 141
+  - uid: 482
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 142
+  - uid: 483
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 143
+  - uid: 484
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 145
+  - uid: 485
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 146
+  - uid: 486
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 147
+  - uid: 487
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 148
+  - uid: 488
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 149
+  - uid: 489
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 152
+  - uid: 490
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 153
+  - uid: 491
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 154
+  - uid: 492
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 172
+  - uid: 493
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 176
+  - uid: 494
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 1
-  - uid: 178
+  - uid: 495
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
-  - uid: 179
+  - uid: 496
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-  - uid: 182
+  - uid: 497
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 193
+  - uid: 498
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 195
+  - uid: 499
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 203
+  - uid: 500
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
-  - uid: 206
+  - uid: 501
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 208
+  - uid: 502
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 1
-  - uid: 209
+  - uid: 503
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 16
+  - uid: 504
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-12.5
       parent: 1
-  - uid: 17
+  - uid: 505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-12.5
       parent: 1
-  - uid: 18
+  - uid: 506
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-12.5
       parent: 1
-  - uid: 19
+  - uid: 507
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-12.5
       parent: 1
-  - uid: 97
+  - uid: 508
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 1
-  - uid: 111
+  - uid: 509
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
-  - uid: 177
+  - uid: 510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-8.5
       parent: 1
-  - uid: 180
+  - uid: 511
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 181
+  - uid: 512
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 183
+  - uid: 513
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3705,280 +3690,280 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 29
+  - uid: 514
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 31
+  - uid: 515
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 34
+  - uid: 516
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 57
+  - uid: 517
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 58
+  - uid: 518
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 59
+  - uid: 519
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 60
+  - uid: 520
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 61
+  - uid: 521
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 62
+  - uid: 522
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 63
+  - uid: 523
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 64
+  - uid: 524
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 65
+  - uid: 525
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 66
+  - uid: 526
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 67
+  - uid: 527
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 68
+  - uid: 528
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 71
+  - uid: 529
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 72
+  - uid: 530
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 73
+  - uid: 531
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 81
+  - uid: 532
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 100
+  - uid: 533
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 101
+  - uid: 534
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 102
+  - uid: 535
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 103
+  - uid: 536
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 129
+  - uid: 537
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 130
+  - uid: 538
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 131
+  - uid: 539
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 132
+  - uid: 540
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 133
+  - uid: 541
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 134
+  - uid: 542
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 155
+  - uid: 543
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 159
+  - uid: 544
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 160
+  - uid: 545
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 161
+  - uid: 546
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 162
+  - uid: 547
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 163
+  - uid: 548
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 164
+  - uid: 549
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 165
+  - uid: 550
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 166
+  - uid: 551
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 167
+  - uid: 552
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 168
+  - uid: 553
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 169
+  - uid: 554
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 170
+  - uid: 555
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 171
+  - uid: 556
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 173
+  - uid: 557
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 174
+  - uid: 558
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 175
+  - uid: 559
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 204
+  - uid: 560
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 1
-  - uid: 205
+  - uid: 561
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 207
+  - uid: 562
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 211
+  - uid: 563
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 267
+  - uid: 564
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 268
+  - uid: 565
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 270
+  - uid: 566
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 269
+  - uid: 567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,10.5
       parent: 1
-  - uid: 271
+  - uid: 568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3986,14 +3971,14 @@ entities:
       parent: 1
 - proto: WarpPointAdmin
   entities:
-  - uid: 521
+  - uid: 569
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
 - proto: WeaponTurretCyrexa
   entities:
-  - uid: 272
+  - uid: 570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4001,37 +3986,37 @@ entities:
       parent: 1
 - proto: WeaponTurretL85Autocannon
   entities:
-  - uid: 99
+  - uid: 571
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,10.5
       parent: 1
-  - uid: 191
+  - uid: 572
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 192
+  - uid: 573
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
 - proto: WeaponTurretVanyk
   entities:
-  - uid: 95
+  - uid: 574
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,12.5
       parent: 1
-  - uid: 200
+  - uid: 575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-  - uid: 274
+  - uid: 576
     components:
     - type: Transform
       rot: 1.5707963267948966 rad

--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/vulture.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/vulture.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.2.0
+  engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 06/18/2025 19:20:47
-  entityCount: 2500
+  time: 06/29/2025 02:19:14
+  entityCount: 2497
 maps: []
 grids:
 - 1
@@ -123,6 +123,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
+      dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -967,7 +968,7 @@ entities:
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
-  - uid: 867
+  - uid: 5
     components:
     - type: MetaData
     - type: Transform
@@ -980,9 +981,22 @@ entities:
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
+  - uid: 976
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 10.98699,10.087136
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
 - proto: AirAlarm
   entities:
-  - uid: 5
+  - uid: 6
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -990,25 +1004,25 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1026
-      - 1027
-      - 1025
-      - 1024
-      - 1023
-      - 1034
-      - 1033
-      - 1031
-      - 1032
-      - 1030
-      - 1028
-      - 1029
-      - 1210
-      - 1219
-      - 1212
-      - 1221
-      - 1220
-      - 1211
-  - uid: 6
+      - 1135
+      - 1136
+      - 1134
+      - 1133
+      - 1132
+      - 1143
+      - 1142
+      - 1140
+      - 1141
+      - 1139
+      - 1137
+      - 1138
+      - 1317
+      - 1326
+      - 1319
+      - 1328
+      - 1327
+      - 1318
+  - uid: 7
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1016,13 +1030,13 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1213
-      - 1222
-      - 1034
-      - 1033
-      - 1035
-      - 1036
-  - uid: 7
+      - 1320
+      - 1329
+      - 1143
+      - 1142
+      - 1144
+      - 1145
+  - uid: 8
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1030,15 +1044,15 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1035
-      - 1036
-      - 1037
-      - 1038
-      - 1040
-      - 1041
-      - 1225
-      - 1216
-  - uid: 8
+      - 1144
+      - 1145
+      - 1146
+      - 1147
+      - 1149
+      - 1150
+      - 1332
+      - 1323
+  - uid: 9
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1046,12 +1060,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1031
-      - 1037
-      - 1032
-      - 1215
-      - 1224
-  - uid: 9
+      - 1140
+      - 1146
+      - 1141
+      - 1322
+      - 1331
+  - uid: 10
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1059,158 +1073,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1039
-      - 1038
-      - 1223
-      - 1214
-- proto: AirlockHatchRogueLocked
+      - 1148
+      - 1147
+      - 1330
+      - 1321
+- proto: AirlockGlassShuttleSyndicate
   entities:
-  - uid: 10
-    components:
-    - type: Transform
-      pos: 5.5,5.5
-      parent: 1
-  - uid: 11
-    components:
-    - type: Transform
-      pos: 4.5,5.5
-      parent: 1
-  - uid: 12
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-3.5
-      parent: 1
-  - uid: 13
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-3.5
-      parent: 1
-  - uid: 14
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,0.5
-      parent: 1
-  - uid: 15
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 16
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-20.5
-      parent: 1
-  - uid: 17
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-20.5
-      parent: 1
-  - uid: 18
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-20.5
-      parent: 1
-  - uid: 19
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-6.5
-      parent: 1
-  - uid: 20
-    components:
-    - type: Transform
-      pos: 4.5,11.5
-      parent: 1
-  - uid: 21
-    components:
-    - type: Transform
-      pos: 5.5,11.5
-      parent: 1
-  - uid: 22
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-12.5
-      parent: 1
-  - uid: 23
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-11.5
-      parent: 1
-  - uid: 24
-    components:
-    - type: Transform
-      pos: 4.5,-4.5
-      parent: 1
-  - uid: 25
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-  - uid: 26
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,26.5
-      parent: 1
-  - uid: 27
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,25.5
-      parent: 1
-  - uid: 28
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,24.5
-      parent: 1
-  - uid: 29
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,23.5
-      parent: 1
-  - uid: 32
-    components:
-    - type: Transform
-      pos: 23.5,31.5
-      parent: 1
-  - uid: 2444
-    components:
-    - type: Transform
-      pos: 23.5,35.5
-      parent: 1
-  - uid: 2447
-    components:
-    - type: Transform
-      pos: 23.5,43.5
-      parent: 1
-  - uid: 2494
-    components:
-    - type: Transform
-      pos: 23.5,42.5
-      parent: 1
-- proto: AirlockShuttleSyndicateRogueLocked
-  entities:
-  - uid: 33
-    components:
-    - type: Transform
-      pos: 11.5,-22.5
-      parent: 1
-  - uid: 34
-    components:
-    - type: Transform
-      pos: 10.5,-22.5
-      parent: 1
   - uid: 35
     components:
     - type: Transform
@@ -1219,91 +1087,237 @@ entities:
   - uid: 36
     components:
     - type: Transform
-      pos: 8.5,-22.5
+      pos: 10.5,-22.5
       parent: 1
   - uid: 37
     components:
     - type: Transform
+      pos: 11.5,-22.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
       pos: 12.5,-22.5
       parent: 1
-  - uid: 2424
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 8.5,-22.5
+      parent: 1
+  - uid: 40
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,31.5
       parent: 1
-  - uid: 2448
+  - uid: 41
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,35.5
       parent: 1
-  - uid: 2495
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.5,43.5
-      parent: 1
-  - uid: 2496
+  - uid: 42
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,42.5
       parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.5,43.5
+      parent: 1
+- proto: AirlockHatchPirateLocked
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-3.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-20.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-20.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-20.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-6.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-12.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,26.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,25.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,24.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,23.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 23.5,31.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 23.5,35.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 23.5,43.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 23.5,42.5
+      parent: 1
 - proto: AlwaysPoweredlightGreen
   entities:
-  - uid: 38
+  - uid: 44
     components:
     - type: Transform
       pos: 0.5,48.5
       parent: 1
-  - uid: 2490
+  - uid: 45
     components:
     - type: Transform
       pos: 17.5,55.5
       parent: 1
-  - uid: 2493
+  - uid: 46
     components:
     - type: Transform
       pos: 21.5,56.5
       parent: 1
 - proto: AlwaysPoweredlightRed
   entities:
-  - uid: 40
+  - uid: 47
     components:
     - type: Transform
       pos: -1.5,46.5
       parent: 1
-  - uid: 2369
+  - uid: 48
     components:
     - type: Transform
       pos: -3.5,51.5
       parent: 1
-  - uid: 2491
+  - uid: 49
     components:
     - type: Transform
       pos: 24.5,54.5
       parent: 1
-  - uid: 2492
+  - uid: 50
     components:
     - type: Transform
       pos: 19.5,54.5
       parent: 1
 - proto: AlwaysPoweredLightSodium
   entities:
-  - uid: 755
+  - uid: 51
     components:
     - type: Transform
       pos: 13.5,26.5
       parent: 1
-  - uid: 2267
+  - uid: 52
     components:
     - type: Transform
       pos: 7.5,26.5
       parent: 1
 - proto: AmeController
   entities:
-  - uid: 42
+  - uid: 53
     components:
     - type: Transform
       pos: 2.5,-9.5
@@ -1315,43 +1329,43 @@ entities:
         fuelSlot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 43
+          ent: 54
 - proto: AmeJar
   entities:
-  - uid: 43
+  - uid: 54
     components:
     - type: Transform
-      parent: 42
+      parent: 53
     - type: Physics
       canCollide: False
 - proto: AmeShielding
   entities:
-  - uid: 44
+  - uid: 55
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 45
+  - uid: 56
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 46
+  - uid: 57
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 47
+  - uid: 58
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
-  - uid: 48
+  - uid: 59
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 49
+  - uid: 60
     components:
     - type: Transform
       pos: 3.5,-12.5
@@ -1359,7 +1373,7 @@ entities:
     - type: PointLight
       radius: 1
       enabled: True
-  - uid: 50
+  - uid: 61
     components:
     - type: Transform
       pos: 3.5,-11.5
@@ -1367,746 +1381,746 @@ entities:
     - type: PointLight
       radius: 1
       enabled: True
-  - uid: 51
+  - uid: 62
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 52
+  - uid: 63
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 53
+  - uid: 64
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 54
+  - uid: 65
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 55
+  - uid: 66
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
 - proto: AmmoTechFab
   entities:
-  - uid: 56
+  - uid: 67
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
 - proto: APCHighCapacity
   entities:
-  - uid: 57
+  - uid: 68
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,22.5
       parent: 1
-  - uid: 58
+  - uid: 69
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,44.5
       parent: 1
-  - uid: 59
+  - uid: 70
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 60
+  - uid: 71
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 61
+  - uid: 72
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-0.5
       parent: 1
-  - uid: 62
+  - uid: 73
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-16.5
       parent: 1
-  - uid: 63
+  - uid: 74
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 64
+  - uid: 75
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,11.5
       parent: 1
-  - uid: 65
+  - uid: 76
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,11.5
       parent: 1
-  - uid: 66
+  - uid: 77
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,11.5
       parent: 1
-  - uid: 67
+  - uid: 78
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,11.5
       parent: 1
-  - uid: 68
+  - uid: 79
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,11.5
       parent: 1
-  - uid: 2168
+  - uid: 80
     components:
     - type: Transform
       pos: 8.5,-22.5
       parent: 1
-  - uid: 2169
+  - uid: 81
     components:
     - type: Transform
       pos: 9.5,-22.5
       parent: 1
-  - uid: 2170
+  - uid: 82
     components:
     - type: Transform
       pos: 10.5,-22.5
       parent: 1
-  - uid: 2171
+  - uid: 83
     components:
     - type: Transform
       pos: 11.5,-22.5
       parent: 1
-  - uid: 2172
+  - uid: 84
     components:
     - type: Transform
       pos: 12.5,-22.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 69
+  - uid: 85
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,37.5
       parent: 1
-  - uid: 70
+  - uid: 86
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,38.5
       parent: 1
-  - uid: 71
+  - uid: 87
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,39.5
       parent: 1
-  - uid: 72
+  - uid: 88
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,40.5
       parent: 1
-  - uid: 73
+  - uid: 89
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,41.5
       parent: 1
-  - uid: 74
+  - uid: 90
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,42.5
       parent: 1
-  - uid: 75
+  - uid: 91
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,43.5
       parent: 1
-  - uid: 76
+  - uid: 92
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,21.5
       parent: 1
-  - uid: 77
+  - uid: 93
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,22.5
       parent: 1
-  - uid: 78
+  - uid: 94
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,23.5
       parent: 1
-  - uid: 79
+  - uid: 95
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,24.5
       parent: 1
-  - uid: 80
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,25.5
       parent: 1
-  - uid: 81
+  - uid: 97
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,26.5
       parent: 1
-  - uid: 82
+  - uid: 98
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,27.5
       parent: 1
-  - uid: 83
+  - uid: 99
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,28.5
       parent: 1
-  - uid: 84
+  - uid: 100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,29.5
       parent: 1
-  - uid: 85
+  - uid: 101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,30.5
       parent: 1
-  - uid: 86
+  - uid: 102
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,31.5
       parent: 1
-  - uid: 87
+  - uid: 103
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,32.5
       parent: 1
-  - uid: 88
+  - uid: 104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,33.5
       parent: 1
-  - uid: 89
+  - uid: 105
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,34.5
       parent: 1
-  - uid: 90
+  - uid: 106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,35.5
       parent: 1
-  - uid: 91
+  - uid: 107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,36.5
       parent: 1
-  - uid: 92
+  - uid: 108
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,41.5
       parent: 1
-  - uid: 93
+  - uid: 109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,42.5
       parent: 1
-  - uid: 94
+  - uid: 110
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,43.5
       parent: 1
-  - uid: 95
+  - uid: 111
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,21.5
       parent: 1
-  - uid: 96
+  - uid: 112
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,22.5
       parent: 1
-  - uid: 97
+  - uid: 113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,23.5
       parent: 1
-  - uid: 98
+  - uid: 114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,24.5
       parent: 1
-  - uid: 99
+  - uid: 115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,25.5
       parent: 1
-  - uid: 100
+  - uid: 116
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,26.5
       parent: 1
-  - uid: 101
+  - uid: 117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,27.5
       parent: 1
-  - uid: 102
+  - uid: 118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,28.5
       parent: 1
-  - uid: 103
+  - uid: 119
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,29.5
       parent: 1
-  - uid: 104
+  - uid: 120
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,30.5
       parent: 1
-  - uid: 105
+  - uid: 121
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,31.5
       parent: 1
-  - uid: 106
+  - uid: 122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,32.5
       parent: 1
-  - uid: 107
+  - uid: 123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,33.5
       parent: 1
-  - uid: 108
+  - uid: 124
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,34.5
       parent: 1
-  - uid: 109
+  - uid: 125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,35.5
       parent: 1
-  - uid: 110
+  - uid: 126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,36.5
       parent: 1
-  - uid: 111
+  - uid: 127
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,37.5
       parent: 1
-  - uid: 112
+  - uid: 128
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,38.5
       parent: 1
-  - uid: 113
+  - uid: 129
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,21.5
       parent: 1
-  - uid: 114
+  - uid: 130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,22.5
       parent: 1
-  - uid: 115
+  - uid: 131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,23.5
       parent: 1
-  - uid: 116
+  - uid: 132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,25.5
       parent: 1
-  - uid: 117
+  - uid: 133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,24.5
       parent: 1
-  - uid: 118
+  - uid: 134
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,26.5
       parent: 1
-  - uid: 119
+  - uid: 135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,27.5
       parent: 1
-  - uid: 120
+  - uid: 136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,28.5
       parent: 1
-  - uid: 121
+  - uid: 137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,29.5
       parent: 1
-  - uid: 122
+  - uid: 138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,30.5
       parent: 1
-  - uid: 123
+  - uid: 139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,31.5
       parent: 1
-  - uid: 124
+  - uid: 140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,32.5
       parent: 1
-  - uid: 125
+  - uid: 141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,33.5
       parent: 1
-  - uid: 126
+  - uid: 142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,34.5
       parent: 1
-  - uid: 127
+  - uid: 143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,35.5
       parent: 1
-  - uid: 128
+  - uid: 144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,36.5
       parent: 1
-  - uid: 129
+  - uid: 145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,37.5
       parent: 1
-  - uid: 130
+  - uid: 146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,38.5
       parent: 1
-  - uid: 131
+  - uid: 147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,39.5
       parent: 1
-  - uid: 132
+  - uid: 148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,40.5
       parent: 1
-  - uid: 133
+  - uid: 149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,39.5
       parent: 1
-  - uid: 134
+  - uid: 150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,40.5
       parent: 1
-  - uid: 135
+  - uid: 151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,41.5
       parent: 1
-  - uid: 136
+  - uid: 152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,42.5
       parent: 1
-  - uid: 137
+  - uid: 153
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,43.5
       parent: 1
-  - uid: 138
+  - uid: 154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,44.5
       parent: 1
-  - uid: 139
+  - uid: 155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,45.5
       parent: 1
-  - uid: 140
+  - uid: 156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,44.5
       parent: 1
-  - uid: 141
+  - uid: 157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,45.5
       parent: 1
-  - uid: 142
+  - uid: 158
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,44.5
       parent: 1
-  - uid: 143
+  - uid: 159
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,43.5
       parent: 1
-  - uid: 144
+  - uid: 160
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,42.5
       parent: 1
-  - uid: 145
+  - uid: 161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,41.5
       parent: 1
-  - uid: 146
+  - uid: 162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,40.5
       parent: 1
-  - uid: 147
+  - uid: 163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,39.5
       parent: 1
-  - uid: 148
+  - uid: 164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,37.5
       parent: 1
-  - uid: 149
+  - uid: 165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,38.5
       parent: 1
-  - uid: 150
+  - uid: 166
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,36.5
       parent: 1
-  - uid: 151
+  - uid: 167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,35.5
       parent: 1
-  - uid: 152
+  - uid: 168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,34.5
       parent: 1
-  - uid: 153
+  - uid: 169
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,33.5
       parent: 1
-  - uid: 154
+  - uid: 170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,32.5
       parent: 1
-  - uid: 155
+  - uid: 171
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,31.5
       parent: 1
-  - uid: 156
+  - uid: 172
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,30.5
       parent: 1
-  - uid: 157
+  - uid: 173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,29.5
       parent: 1
-  - uid: 158
+  - uid: 174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,28.5
       parent: 1
-  - uid: 159
+  - uid: 175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,27.5
       parent: 1
-  - uid: 160
+  - uid: 176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,26.5
       parent: 1
-  - uid: 161
+  - uid: 177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,25.5
       parent: 1
-  - uid: 162
+  - uid: 178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,23.5
       parent: 1
-  - uid: 163
+  - uid: 179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,23.5
       parent: 1
-  - uid: 164
+  - uid: 180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,23.5
       parent: 1
-  - uid: 165
+  - uid: 181
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,24.5
       parent: 1
-  - uid: 166
+  - uid: 182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,24.5
       parent: 1
-  - uid: 167
+  - uid: 183
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,24.5
       parent: 1
-  - uid: 168
+  - uid: 184
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,25.5
       parent: 1
-  - uid: 169
+  - uid: 185
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,24.5
       parent: 1
-  - uid: 170
+  - uid: 186
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2114,7 +2128,7 @@ entities:
       parent: 1
 - proto: BenchSofaCorpLeft
   entities:
-  - uid: 171
+  - uid: 187
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2122,7 +2136,7 @@ entities:
       parent: 1
 - proto: BenchSofaCorpMiddle
   entities:
-  - uid: 172
+  - uid: 188
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2130,7 +2144,7 @@ entities:
       parent: 1
 - proto: BenchSofaCorpRight
   entities:
-  - uid: 173
+  - uid: 189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2138,166 +2152,166 @@ entities:
       parent: 1
 - proto: BiomassReclaimer
   entities:
-  - uid: 174
+  - uid: 190
     components:
     - type: Transform
       pos: 22.5,36.5
       parent: 1
 - proto: BlastDoorOpen
   entities:
-  - uid: 175
+  - uid: 191
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 176
+  - uid: 192
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 177
+  - uid: 193
     components:
     - type: Transform
       pos: 16.5,4.5
       parent: 1
-  - uid: 178
+  - uid: 194
     components:
     - type: Transform
       pos: 15.5,4.5
       parent: 1
-  - uid: 179
+  - uid: 195
     components:
     - type: Transform
       pos: 16.5,5.5
       parent: 1
-  - uid: 180
+  - uid: 196
     components:
     - type: Transform
       pos: 15.5,5.5
       parent: 1
-  - uid: 181
+  - uid: 197
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 182
+  - uid: 198
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 183
+  - uid: 199
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 184
+  - uid: 200
     components:
     - type: Transform
       pos: 14.5,-3.5
       parent: 1
-  - uid: 185
+  - uid: 201
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 1
-  - uid: 186
+  - uid: 202
     components:
     - type: Transform
       pos: 17.5,11.5
       parent: 1
-  - uid: 187
+  - uid: 203
     components:
     - type: Transform
       pos: 17.5,4.5
       parent: 1
-  - uid: 188
+  - uid: 204
     components:
     - type: Transform
       pos: 17.5,5.5
       parent: 1
-  - uid: 189
+  - uid: 205
     components:
     - type: Transform
       pos: 11.5,-20.5
       parent: 1
-  - uid: 190
+  - uid: 206
     components:
     - type: Transform
       pos: 12.5,-20.5
       parent: 1
-  - uid: 191
+  - uid: 207
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 1
-  - uid: 192
+  - uid: 208
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 1
 - proto: BoozeDispenser
   entities:
-  - uid: 193
+  - uid: 209
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
 - proto: ButtonFrameCautionSecurity
   entities:
-  - uid: 194
+  - uid: 210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-19.5
       parent: 1
-  - uid: 195
+  - uid: 211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 1
-  - uid: 196
+  - uid: 212
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 197
+  - uid: 213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,3.5
       parent: 1
-  - uid: 198
+  - uid: 214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,10.5
       parent: 1
-  - uid: 199
+  - uid: 215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,23.5
       parent: 1
-  - uid: 200
+  - uid: 216
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,29.5
       parent: 1
-  - uid: 201
+  - uid: 217
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,33.5
       parent: 1
-  - uid: 202
+  - uid: 218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,37.5
       parent: 1
-  - uid: 203
+  - uid: 219
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2305,2438 +2319,2438 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 204
+  - uid: 220
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 1
-  - uid: 205
+  - uid: 221
     components:
     - type: Transform
       pos: 4.5,21.5
       parent: 1
-  - uid: 206
+  - uid: 222
     components:
     - type: Transform
       pos: 4.5,20.5
       parent: 1
-  - uid: 207
+  - uid: 223
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 208
+  - uid: 224
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 209
+  - uid: 225
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 1
-  - uid: 210
+  - uid: 226
     components:
     - type: Transform
       pos: 4.5,16.5
       parent: 1
-  - uid: 211
+  - uid: 227
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 212
+  - uid: 228
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 1
-  - uid: 213
+  - uid: 229
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 214
+  - uid: 230
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 215
+  - uid: 231
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 216
+  - uid: 232
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
-  - uid: 217
+  - uid: 233
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 1
-  - uid: 218
+  - uid: 234
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 1
-  - uid: 219
+  - uid: 235
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 1
-  - uid: 220
+  - uid: 236
     components:
     - type: Transform
       pos: 9.5,11.5
       parent: 1
-  - uid: 221
+  - uid: 237
     components:
     - type: Transform
       pos: 10.5,11.5
       parent: 1
-  - uid: 222
+  - uid: 238
     components:
     - type: Transform
       pos: 11.5,11.5
       parent: 1
-  - uid: 223
+  - uid: 239
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 1
-  - uid: 224
+  - uid: 240
     components:
     - type: Transform
       pos: 12.5,12.5
       parent: 1
-  - uid: 225
+  - uid: 241
     components:
     - type: Transform
       pos: 13.5,12.5
       parent: 1
-  - uid: 226
+  - uid: 242
     components:
     - type: Transform
       pos: 14.5,12.5
       parent: 1
-  - uid: 227
+  - uid: 243
     components:
     - type: Transform
       pos: 14.5,22.5
       parent: 1
-  - uid: 228
+  - uid: 244
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 1
-  - uid: 229
+  - uid: 245
     components:
     - type: Transform
       pos: 8.5,16.5
       parent: 1
-  - uid: 230
+  - uid: 246
     components:
     - type: Transform
       pos: 8.5,17.5
       parent: 1
-  - uid: 231
+  - uid: 247
     components:
     - type: Transform
       pos: 8.5,18.5
       parent: 1
-  - uid: 232
+  - uid: 248
     components:
     - type: Transform
       pos: 8.5,19.5
       parent: 1
-  - uid: 233
+  - uid: 249
     components:
     - type: Transform
       pos: 8.5,20.5
       parent: 1
-  - uid: 234
+  - uid: 250
     components:
     - type: Transform
       pos: 8.5,21.5
       parent: 1
-  - uid: 235
+  - uid: 251
     components:
     - type: Transform
       pos: 8.5,13.5
       parent: 1
-  - uid: 236
+  - uid: 252
     components:
     - type: Transform
       pos: 8.5,15.5
       parent: 1
-  - uid: 237
+  - uid: 253
     components:
     - type: Transform
       pos: 13.5,22.5
       parent: 1
-  - uid: 238
+  - uid: 254
     components:
     - type: Transform
       pos: 12.5,21.5
       parent: 1
-  - uid: 239
+  - uid: 255
     components:
     - type: Transform
       pos: 12.5,20.5
       parent: 1
-  - uid: 240
+  - uid: 256
     components:
     - type: Transform
       pos: 12.5,19.5
       parent: 1
-  - uid: 241
+  - uid: 257
     components:
     - type: Transform
       pos: 12.5,18.5
       parent: 1
-  - uid: 242
+  - uid: 258
     components:
     - type: Transform
       pos: 12.5,17.5
       parent: 1
-  - uid: 243
+  - uid: 259
     components:
     - type: Transform
       pos: 12.5,16.5
       parent: 1
-  - uid: 244
+  - uid: 260
     components:
     - type: Transform
       pos: 12.5,15.5
       parent: 1
-  - uid: 245
+  - uid: 261
     components:
     - type: Transform
       pos: 12.5,14.5
       parent: 1
-  - uid: 246
+  - uid: 262
     components:
     - type: Transform
       pos: 12.5,13.5
       parent: 1
-  - uid: 247
+  - uid: 263
     components:
     - type: Transform
       pos: -0.5,28.5
       parent: 1
-  - uid: 248
+  - uid: 264
     components:
     - type: Transform
       pos: 3.5,21.5
       parent: 1
-  - uid: 249
+  - uid: 265
     components:
     - type: Transform
       pos: 2.5,21.5
       parent: 1
-  - uid: 250
+  - uid: 266
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 1
-  - uid: 251
+  - uid: 267
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 252
+  - uid: 268
     components:
     - type: Transform
       pos: -1.5,21.5
       parent: 1
-  - uid: 253
+  - uid: 269
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 1
-  - uid: 254
+  - uid: 270
     components:
     - type: Transform
       pos: 1.5,22.5
       parent: 1
-  - uid: 255
+  - uid: 271
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 1
-  - uid: 256
+  - uid: 272
     components:
     - type: Transform
       pos: 1.5,25.5
       parent: 1
-  - uid: 257
+  - uid: 273
     components:
     - type: Transform
       pos: 1.5,26.5
       parent: 1
-  - uid: 258
+  - uid: 274
     components:
     - type: Transform
       pos: 1.5,27.5
       parent: 1
-  - uid: 259
+  - uid: 275
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 1
-  - uid: 260
+  - uid: 276
     components:
     - type: Transform
       pos: 0.5,27.5
       parent: 1
-  - uid: 261
+  - uid: 277
     components:
     - type: Transform
       pos: -0.5,27.5
       parent: 1
-  - uid: 262
+  - uid: 278
     components:
     - type: Transform
       pos: -0.5,29.5
       parent: 1
-  - uid: 263
+  - uid: 279
     components:
     - type: Transform
       pos: -0.5,30.5
       parent: 1
-  - uid: 264
+  - uid: 280
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 1
-  - uid: 265
+  - uid: 281
     components:
     - type: Transform
       pos: -0.5,32.5
       parent: 1
-  - uid: 266
+  - uid: 282
     components:
     - type: Transform
       pos: -0.5,33.5
       parent: 1
-  - uid: 267
+  - uid: 283
     components:
     - type: Transform
       pos: -0.5,34.5
       parent: 1
-  - uid: 268
+  - uid: 284
     components:
     - type: Transform
       pos: -0.5,35.5
       parent: 1
-  - uid: 269
+  - uid: 285
     components:
     - type: Transform
       pos: -0.5,36.5
       parent: 1
-  - uid: 270
+  - uid: 286
     components:
     - type: Transform
       pos: -0.5,37.5
       parent: 1
-  - uid: 271
+  - uid: 287
     components:
     - type: Transform
       pos: -0.5,38.5
       parent: 1
-  - uid: 272
+  - uid: 288
     components:
     - type: Transform
       pos: -0.5,39.5
       parent: 1
-  - uid: 273
+  - uid: 289
     components:
     - type: Transform
       pos: -0.5,40.5
       parent: 1
-  - uid: 274
+  - uid: 290
     components:
     - type: Transform
       pos: -0.5,41.5
       parent: 1
-  - uid: 275
+  - uid: 291
     components:
     - type: Transform
       pos: 15.5,12.5
       parent: 1
-  - uid: 276
+  - uid: 292
     components:
     - type: Transform
       pos: 15.5,13.5
       parent: 1
-  - uid: 277
+  - uid: 293
     components:
     - type: Transform
       pos: 15.5,14.5
       parent: 1
-  - uid: 278
+  - uid: 294
     components:
     - type: Transform
       pos: 15.5,16.5
       parent: 1
-  - uid: 279
+  - uid: 295
     components:
     - type: Transform
       pos: 15.5,15.5
       parent: 1
-  - uid: 280
+  - uid: 296
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 1
-  - uid: 281
+  - uid: 297
     components:
     - type: Transform
       pos: 15.5,18.5
       parent: 1
-  - uid: 282
+  - uid: 298
     components:
     - type: Transform
       pos: 15.5,19.5
       parent: 1
-  - uid: 283
+  - uid: 299
     components:
     - type: Transform
       pos: 15.5,20.5
       parent: 1
-  - uid: 284
+  - uid: 300
     components:
     - type: Transform
       pos: 15.5,21.5
       parent: 1
-  - uid: 285
+  - uid: 301
     components:
     - type: Transform
       pos: 15.5,22.5
       parent: 1
-  - uid: 286
+  - uid: 302
     components:
     - type: Transform
       pos: 22.5,44.5
       parent: 1
-  - uid: 287
+  - uid: 303
     components:
     - type: Transform
       pos: 20.5,44.5
       parent: 1
-  - uid: 288
+  - uid: 304
     components:
     - type: Transform
       pos: 21.5,44.5
       parent: 1
-  - uid: 289
+  - uid: 305
     components:
     - type: Transform
       pos: 19.5,44.5
       parent: 1
-  - uid: 290
+  - uid: 306
     components:
     - type: Transform
       pos: 20.5,43.5
       parent: 1
-  - uid: 291
+  - uid: 307
     components:
     - type: Transform
       pos: 20.5,41.5
       parent: 1
-  - uid: 292
+  - uid: 308
     components:
     - type: Transform
       pos: 20.5,40.5
       parent: 1
-  - uid: 293
+  - uid: 309
     components:
     - type: Transform
       pos: 20.5,39.5
       parent: 1
-  - uid: 294
+  - uid: 310
     components:
     - type: Transform
       pos: 20.5,38.5
       parent: 1
-  - uid: 295
+  - uid: 311
     components:
     - type: Transform
       pos: 20.5,37.5
       parent: 1
-  - uid: 296
+  - uid: 312
     components:
     - type: Transform
       pos: 20.5,36.5
       parent: 1
-  - uid: 297
+  - uid: 313
     components:
     - type: Transform
       pos: 20.5,35.5
       parent: 1
-  - uid: 298
+  - uid: 314
     components:
     - type: Transform
       pos: 20.5,34.5
       parent: 1
-  - uid: 299
+  - uid: 315
     components:
     - type: Transform
       pos: 20.5,33.5
       parent: 1
-  - uid: 300
+  - uid: 316
     components:
     - type: Transform
       pos: 20.5,32.5
       parent: 1
-  - uid: 301
+  - uid: 317
     components:
     - type: Transform
       pos: 20.5,31.5
       parent: 1
-  - uid: 302
+  - uid: 318
     components:
     - type: Transform
       pos: 20.5,30.5
       parent: 1
-  - uid: 303
+  - uid: 319
     components:
     - type: Transform
       pos: 20.5,29.5
       parent: 1
-  - uid: 304
+  - uid: 320
     components:
     - type: Transform
       pos: 20.5,28.5
       parent: 1
-  - uid: 305
+  - uid: 321
     components:
     - type: Transform
       pos: 20.5,27.5
       parent: 1
-  - uid: 306
+  - uid: 322
     components:
     - type: Transform
       pos: 20.5,26.5
       parent: 1
-  - uid: 307
+  - uid: 323
     components:
     - type: Transform
       pos: 20.5,25.5
       parent: 1
-  - uid: 308
+  - uid: 324
     components:
     - type: Transform
       pos: 20.5,42.5
       parent: 1
-  - uid: 309
+  - uid: 325
     components:
     - type: Transform
       pos: 20.5,24.5
       parent: 1
-  - uid: 310
+  - uid: 326
     components:
     - type: Transform
       pos: 20.5,23.5
       parent: 1
-  - uid: 311
+  - uid: 327
     components:
     - type: Transform
       pos: 19.5,23.5
       parent: 1
-  - uid: 312
+  - uid: 328
     components:
     - type: Transform
       pos: 18.5,23.5
       parent: 1
-  - uid: 313
+  - uid: 329
     components:
     - type: Transform
       pos: 17.5,23.5
       parent: 1
-  - uid: 314
+  - uid: 330
     components:
     - type: Transform
       pos: 16.5,23.5
       parent: 1
-  - uid: 315
+  - uid: 331
     components:
     - type: Transform
       pos: 7.5,-16.5
       parent: 1
-  - uid: 316
+  - uid: 332
     components:
     - type: Transform
       pos: 8.5,-16.5
       parent: 1
-  - uid: 317
+  - uid: 333
     components:
     - type: Transform
       pos: 9.5,-16.5
       parent: 1
-  - uid: 318
+  - uid: 334
     components:
     - type: Transform
       pos: 10.5,-16.5
       parent: 1
-  - uid: 319
+  - uid: 335
     components:
     - type: Transform
       pos: 10.5,-17.5
       parent: 1
-  - uid: 320
+  - uid: 336
     components:
     - type: Transform
       pos: 10.5,-18.5
       parent: 1
-  - uid: 321
+  - uid: 337
     components:
     - type: Transform
       pos: 10.5,-19.5
       parent: 1
-  - uid: 322
+  - uid: 338
     components:
     - type: Transform
       pos: 10.5,-21.5
       parent: 1
-  - uid: 323
+  - uid: 339
     components:
     - type: Transform
       pos: 10.5,-20.5
       parent: 1
-  - uid: 324
+  - uid: 340
     components:
     - type: Transform
       pos: 10.5,-15.5
       parent: 1
-  - uid: 325
+  - uid: 341
     components:
     - type: Transform
       pos: 10.5,-14.5
       parent: 1
-  - uid: 326
+  - uid: 342
     components:
     - type: Transform
       pos: 10.5,-12.5
       parent: 1
-  - uid: 327
+  - uid: 343
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 1
-  - uid: 328
+  - uid: 344
     components:
     - type: Transform
       pos: 10.5,-11.5
       parent: 1
-  - uid: 329
+  - uid: 345
     components:
     - type: Transform
       pos: 11.5,-11.5
       parent: 1
-  - uid: 330
+  - uid: 346
     components:
     - type: Transform
       pos: 12.5,-11.5
       parent: 1
-  - uid: 331
+  - uid: 347
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 1
-  - uid: 332
+  - uid: 348
     components:
     - type: Transform
       pos: 14.5,-11.5
       parent: 1
-  - uid: 333
+  - uid: 349
     components:
     - type: Transform
       pos: 15.5,-11.5
       parent: 1
-  - uid: 334
+  - uid: 350
     components:
     - type: Transform
       pos: 16.5,-11.5
       parent: 1
-  - uid: 335
+  - uid: 351
     components:
     - type: Transform
       pos: 16.5,-10.5
       parent: 1
-  - uid: 336
+  - uid: 352
     components:
     - type: Transform
       pos: 16.5,-9.5
       parent: 1
-  - uid: 337
+  - uid: 353
     components:
     - type: Transform
       pos: 16.5,-8.5
       parent: 1
-  - uid: 338
+  - uid: 354
     components:
     - type: Transform
       pos: 16.5,-6.5
       parent: 1
-  - uid: 339
+  - uid: 355
     components:
     - type: Transform
       pos: 16.5,-7.5
       parent: 1
-  - uid: 340
+  - uid: 356
     components:
     - type: Transform
       pos: 16.5,-5.5
       parent: 1
-  - uid: 341
+  - uid: 357
     components:
     - type: Transform
       pos: 16.5,-4.5
       parent: 1
-  - uid: 342
+  - uid: 358
     components:
     - type: Transform
       pos: 16.5,-3.5
       parent: 1
-  - uid: 343
+  - uid: 359
     components:
     - type: Transform
       pos: 16.5,-2.5
       parent: 1
-  - uid: 344
+  - uid: 360
     components:
     - type: Transform
       pos: 16.5,-1.5
       parent: 1
-  - uid: 345
+  - uid: 361
     components:
     - type: Transform
       pos: 16.5,-0.5
       parent: 1
-  - uid: 346
+  - uid: 362
     components:
     - type: Transform
       pos: 16.5,0.5
       parent: 1
-  - uid: 347
+  - uid: 363
     components:
     - type: Transform
       pos: 16.5,1.5
       parent: 1
-  - uid: 348
+  - uid: 364
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 1
-  - uid: 349
+  - uid: 365
     components:
     - type: Transform
       pos: 15.5,2.5
       parent: 1
-  - uid: 350
+  - uid: 366
     components:
     - type: Transform
       pos: 15.5,4.5
       parent: 1
-  - uid: 351
+  - uid: 367
     components:
     - type: Transform
       pos: 15.5,3.5
       parent: 1
-  - uid: 352
+  - uid: 368
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 1
-  - uid: 353
+  - uid: 369
     components:
     - type: Transform
       pos: 15.5,5.5
       parent: 1
-  - uid: 354
+  - uid: 370
     components:
     - type: Transform
       pos: 15.5,7.5
       parent: 1
-  - uid: 355
+  - uid: 371
     components:
     - type: Transform
       pos: 15.5,8.5
       parent: 1
-  - uid: 356
+  - uid: 372
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 1
-  - uid: 357
+  - uid: 373
     components:
     - type: Transform
       pos: 15.5,10.5
       parent: 1
-  - uid: 358
+  - uid: 374
     components:
     - type: Transform
       pos: 21.5,23.5
       parent: 1
-  - uid: 359
+  - uid: 375
     components:
     - type: Transform
       pos: 22.5,23.5
       parent: 1
-  - uid: 360
+  - uid: 376
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 361
+  - uid: 377
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
-  - uid: 362
+  - uid: 378
     components:
     - type: Transform
       pos: 11.5,0.5
       parent: 1
-  - uid: 363
+  - uid: 379
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 1
-  - uid: 364
+  - uid: 380
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 1
-  - uid: 365
+  - uid: 381
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 1
-  - uid: 366
+  - uid: 382
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 1
-  - uid: 367
+  - uid: 383
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 368
+  - uid: 384
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 369
+  - uid: 385
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 370
+  - uid: 386
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 371
+  - uid: 387
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 372
+  - uid: 388
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 373
+  - uid: 389
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 374
+  - uid: 390
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 375
+  - uid: 391
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 376
+  - uid: 392
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 377
+  - uid: 393
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 1
-  - uid: 378
+  - uid: 394
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
-  - uid: 379
+  - uid: 395
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 1
-  - uid: 380
+  - uid: 396
     components:
     - type: Transform
       pos: 9.5,-3.5
       parent: 1
-  - uid: 381
+  - uid: 397
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1
-  - uid: 382
+  - uid: 398
     components:
     - type: Transform
       pos: 11.5,-3.5
       parent: 1
-  - uid: 383
+  - uid: 399
     components:
     - type: Transform
       pos: 12.5,-3.5
       parent: 1
-  - uid: 384
+  - uid: 400
     components:
     - type: Transform
       pos: 13.5,-3.5
       parent: 1
-  - uid: 385
+  - uid: 401
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 386
+  - uid: 402
     components:
     - type: Transform
       pos: 6.5,-12.5
       parent: 1
-  - uid: 387
+  - uid: 403
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 388
+  - uid: 404
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
-  - uid: 389
+  - uid: 405
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 390
+  - uid: 406
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 391
+  - uid: 407
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 392
+  - uid: 408
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 393
+  - uid: 409
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 394
+  - uid: 410
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 395
+  - uid: 411
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 396
+  - uid: 412
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 397
+  - uid: 413
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 398
+  - uid: 414
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 399
+  - uid: 415
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 1
-  - uid: 400
+  - uid: 416
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 1
-  - uid: 401
+  - uid: 417
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 1
-  - uid: 402
+  - uid: 418
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 1
-  - uid: 403
+  - uid: 419
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
-  - uid: 404
+  - uid: 420
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 1
-  - uid: 405
+  - uid: 421
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 406
+  - uid: 422
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 407
+  - uid: 423
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 408
+  - uid: 424
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 409
+  - uid: 425
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 410
+  - uid: 426
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 411
+  - uid: 427
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 412
+  - uid: 428
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 1
-  - uid: 413
+  - uid: 429
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 414
+  - uid: 430
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 415
+  - uid: 431
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
-  - uid: 416
+  - uid: 432
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-  - uid: 417
+  - uid: 433
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 1
-  - uid: 418
+  - uid: 434
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 419
+  - uid: 435
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 420
+  - uid: 436
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 421
+  - uid: 437
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 422
+  - uid: 438
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 423
+  - uid: 439
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 424
+  - uid: 440
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 425
+  - uid: 441
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 426
+  - uid: 442
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 427
+  - uid: 443
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 428
+  - uid: 444
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 429
+  - uid: 445
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 430
+  - uid: 446
     components:
     - type: Transform
       pos: 17.5,-6.5
       parent: 1
-  - uid: 431
+  - uid: 447
     components:
     - type: Transform
       pos: 18.5,-6.5
       parent: 1
-  - uid: 432
+  - uid: 448
     components:
     - type: Transform
       pos: 20.5,-6.5
       parent: 1
-  - uid: 433
+  - uid: 449
     components:
     - type: Transform
       pos: 21.5,-6.5
       parent: 1
-  - uid: 434
+  - uid: 450
     components:
     - type: Transform
       pos: 19.5,-6.5
       parent: 1
-  - uid: 435
+  - uid: 451
     components:
     - type: Transform
       pos: 22.5,-6.5
       parent: 1
-  - uid: 436
+  - uid: 452
     components:
     - type: Transform
       pos: 23.5,-6.5
       parent: 1
-  - uid: 437
+  - uid: 453
     components:
     - type: Transform
       pos: 24.5,-6.5
       parent: 1
-  - uid: 438
+  - uid: 454
     components:
     - type: Transform
       pos: 25.5,-6.5
       parent: 1
-  - uid: 439
+  - uid: 455
     components:
     - type: Transform
       pos: 26.5,-10.5
       parent: 1
-  - uid: 440
+  - uid: 456
     components:
     - type: Transform
       pos: 26.5,-9.5
       parent: 1
-  - uid: 441
+  - uid: 457
     components:
     - type: Transform
       pos: 26.5,-8.5
       parent: 1
-  - uid: 442
+  - uid: 458
     components:
     - type: Transform
       pos: 26.5,-7.5
       parent: 1
-  - uid: 443
+  - uid: 459
     components:
     - type: Transform
       pos: 26.5,-6.5
       parent: 1
-  - uid: 444
+  - uid: 460
     components:
     - type: Transform
       pos: 26.5,-5.5
       parent: 1
-  - uid: 445
+  - uid: 461
     components:
     - type: Transform
       pos: 26.5,-4.5
       parent: 1
-  - uid: 446
+  - uid: 462
     components:
     - type: Transform
       pos: 26.5,-3.5
       parent: 1
-  - uid: 447
+  - uid: 463
     components:
     - type: Transform
       pos: 26.5,-2.5
       parent: 1
-  - uid: 448
+  - uid: 464
     components:
     - type: Transform
       pos: 26.5,-1.5
       parent: 1
-  - uid: 449
+  - uid: 465
     components:
     - type: Transform
       pos: 26.5,-0.5
       parent: 1
-  - uid: 450
+  - uid: 466
     components:
     - type: Transform
       pos: 26.5,0.5
       parent: 1
-  - uid: 451
+  - uid: 467
     components:
     - type: Transform
       pos: 26.5,1.5
       parent: 1
-  - uid: 452
+  - uid: 468
     components:
     - type: Transform
       pos: 26.5,2.5
       parent: 1
-  - uid: 453
+  - uid: 469
     components:
     - type: Transform
       pos: 26.5,3.5
       parent: 1
-  - uid: 454
+  - uid: 470
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 1
-  - uid: 455
+  - uid: 471
     components:
     - type: Transform
       pos: 26.5,5.5
       parent: 1
-  - uid: 456
+  - uid: 472
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1
-  - uid: 457
+  - uid: 473
     components:
     - type: Transform
       pos: 5.5,-17.5
       parent: 1
-  - uid: 458
+  - uid: 474
     components:
     - type: Transform
       pos: 6.5,-17.5
       parent: 1
-  - uid: 459
+  - uid: 475
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 1
-  - uid: 460
+  - uid: 476
     components:
     - type: Transform
       pos: 11.5,-17.5
       parent: 1
-  - uid: 461
+  - uid: 477
     components:
     - type: Transform
       pos: 12.5,-17.5
       parent: 1
-  - uid: 462
+  - uid: 478
     components:
     - type: Transform
       pos: 13.5,-17.5
       parent: 1
-  - uid: 463
+  - uid: 479
     components:
     - type: Transform
       pos: 14.5,-17.5
       parent: 1
-  - uid: 464
+  - uid: 480
     components:
     - type: Transform
       pos: 15.5,-17.5
       parent: 1
-  - uid: 465
+  - uid: 481
     components:
     - type: Transform
       pos: 16.5,-17.5
       parent: 1
-  - uid: 2142
+  - uid: 482
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 2150
+  - uid: 483
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 2175
+  - uid: 484
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 2176
+  - uid: 485
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 2177
+  - uid: 486
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 2178
+  - uid: 487
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 2179
+  - uid: 488
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 2180
+  - uid: 489
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 2181
+  - uid: 490
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 2182
+  - uid: 491
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 2183
+  - uid: 492
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 2184
+  - uid: 493
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 2185
+  - uid: 494
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 2186
+  - uid: 495
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 2187
+  - uid: 496
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 2188
+  - uid: 497
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 2189
+  - uid: 498
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 2190
+  - uid: 499
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 2191
+  - uid: 500
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 2192
+  - uid: 501
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 2193
+  - uid: 502
     components:
     - type: Transform
       pos: 25.5,1.5
       parent: 1
-  - uid: 2194
+  - uid: 503
     components:
     - type: Transform
       pos: 24.5,1.5
       parent: 1
-  - uid: 2195
+  - uid: 504
     components:
     - type: Transform
       pos: 23.5,1.5
       parent: 1
-  - uid: 2196
+  - uid: 505
     components:
     - type: Transform
       pos: 22.5,1.5
       parent: 1
-  - uid: 2197
+  - uid: 506
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 1
-  - uid: 2198
+  - uid: 507
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 1
-  - uid: 2199
+  - uid: 508
     components:
     - type: Transform
       pos: 19.5,1.5
       parent: 1
-  - uid: 2200
+  - uid: 509
     components:
     - type: Transform
       pos: 19.5,-2.5
       parent: 1
-  - uid: 2201
+  - uid: 510
     components:
     - type: Transform
       pos: 20.5,-2.5
       parent: 1
-  - uid: 2202
+  - uid: 511
     components:
     - type: Transform
       pos: 22.5,-2.5
       parent: 1
-  - uid: 2203
+  - uid: 512
     components:
     - type: Transform
       pos: 21.5,-2.5
       parent: 1
-  - uid: 2204
+  - uid: 513
     components:
     - type: Transform
       pos: 23.5,-2.5
       parent: 1
-  - uid: 2205
+  - uid: 514
     components:
     - type: Transform
       pos: 24.5,-2.5
       parent: 1
-  - uid: 2206
+  - uid: 515
     components:
     - type: Transform
       pos: 25.5,-2.5
       parent: 1
-  - uid: 2207
+  - uid: 516
     components:
     - type: Transform
       pos: 18.5,-2.5
       parent: 1
-  - uid: 2208
+  - uid: 517
     components:
     - type: Transform
       pos: 17.5,-2.5
       parent: 1
-  - uid: 2209
+  - uid: 518
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 1
-  - uid: 2210
+  - uid: 519
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 466
+  - uid: 520
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 467
+  - uid: 521
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 468
+  - uid: 522
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 469
+  - uid: 523
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 470
+  - uid: 524
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 471
+  - uid: 525
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 472
+  - uid: 526
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 473
+  - uid: 527
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 474
+  - uid: 528
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 475
+  - uid: 529
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 476
+  - uid: 530
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 477
+  - uid: 531
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 478
+  - uid: 532
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 479
+  - uid: 533
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 480
+  - uid: 534
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 481
+  - uid: 535
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 482
+  - uid: 536
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 483
+  - uid: 537
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
-  - uid: 484
+  - uid: 538
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 485
+  - uid: 539
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 486
+  - uid: 540
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 487
+  - uid: 541
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 488
+  - uid: 542
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 489
+  - uid: 543
     components:
     - type: Transform
       pos: 7.5,-11.5
       parent: 1
-  - uid: 490
+  - uid: 544
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 491
+  - uid: 545
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
-  - uid: 492
+  - uid: 546
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 493
+  - uid: 547
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 494
+  - uid: 548
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 495
+  - uid: 549
     components:
     - type: Transform
       pos: 5.5,23.5
       parent: 1
-  - uid: 496
+  - uid: 550
     components:
     - type: Transform
       pos: 5.5,24.5
       parent: 1
-  - uid: 497
+  - uid: 551
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 1
-  - uid: 498
+  - uid: 552
     components:
     - type: Transform
       pos: 4.5,23.5
       parent: 1
-  - uid: 499
+  - uid: 553
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 1
-  - uid: 500
+  - uid: 554
     components:
     - type: Transform
       pos: 4.5,21.5
       parent: 1
-  - uid: 501
+  - uid: 555
     components:
     - type: Transform
       pos: 3.5,17.5
       parent: 1
-  - uid: 502
+  - uid: 556
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 503
+  - uid: 557
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 504
+  - uid: 558
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 505
+  - uid: 559
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 506
+  - uid: 560
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 507
+  - uid: 561
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 508
+  - uid: 562
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 509
+  - uid: 563
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 510
+  - uid: 564
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 511
+  - uid: 565
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 512
+  - uid: 566
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 513
+  - uid: 567
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
-  - uid: 514
+  - uid: 568
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 1
-  - uid: 515
+  - uid: 569
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 1
-  - uid: 516
+  - uid: 570
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 1
-  - uid: 517
+  - uid: 571
     components:
     - type: Transform
       pos: 9.5,11.5
       parent: 1
-  - uid: 518
+  - uid: 572
     components:
     - type: Transform
       pos: 10.5,11.5
       parent: 1
-  - uid: 519
+  - uid: 573
     components:
     - type: Transform
       pos: 11.5,11.5
       parent: 1
-  - uid: 520
+  - uid: 574
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 1
-  - uid: 521
+  - uid: 575
     components:
     - type: Transform
       pos: 12.5,12.5
       parent: 1
-  - uid: 522
+  - uid: 576
     components:
     - type: Transform
       pos: 13.5,12.5
       parent: 1
-  - uid: 523
+  - uid: 577
     components:
     - type: Transform
       pos: 15.5,12.5
       parent: 1
-  - uid: 524
+  - uid: 578
     components:
     - type: Transform
       pos: 14.5,12.5
       parent: 1
-  - uid: 525
+  - uid: 579
     components:
     - type: Transform
       pos: 20.5,24.5
       parent: 1
-  - uid: 526
+  - uid: 580
     components:
     - type: Transform
       pos: 15.5,13.5
       parent: 1
-  - uid: 527
+  - uid: 581
     components:
     - type: Transform
       pos: 15.5,14.5
       parent: 1
-  - uid: 528
+  - uid: 582
     components:
     - type: Transform
       pos: 15.5,15.5
       parent: 1
-  - uid: 529
+  - uid: 583
     components:
     - type: Transform
       pos: 15.5,16.5
       parent: 1
-  - uid: 530
+  - uid: 584
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 1
-  - uid: 531
+  - uid: 585
     components:
     - type: Transform
       pos: 15.5,18.5
       parent: 1
-  - uid: 532
+  - uid: 586
     components:
     - type: Transform
       pos: 15.5,19.5
       parent: 1
-  - uid: 533
+  - uid: 587
     components:
     - type: Transform
       pos: 15.5,20.5
       parent: 1
-  - uid: 534
+  - uid: 588
     components:
     - type: Transform
       pos: 15.5,21.5
       parent: 1
-  - uid: 535
+  - uid: 589
     components:
     - type: Transform
       pos: 15.5,22.5
       parent: 1
-  - uid: 536
+  - uid: 590
     components:
     - type: Transform
       pos: 15.5,23.5
       parent: 1
-  - uid: 537
+  - uid: 591
     components:
     - type: Transform
       pos: 17.5,23.5
       parent: 1
-  - uid: 538
+  - uid: 592
     components:
     - type: Transform
       pos: 16.5,23.5
       parent: 1
-  - uid: 539
+  - uid: 593
     components:
     - type: Transform
       pos: 18.5,23.5
       parent: 1
-  - uid: 540
+  - uid: 594
     components:
     - type: Transform
       pos: 19.5,23.5
       parent: 1
-  - uid: 541
+  - uid: 595
     components:
     - type: Transform
       pos: 20.5,23.5
       parent: 1
-  - uid: 542
+  - uid: 596
     components:
     - type: Transform
       pos: 20.5,25.5
       parent: 1
-  - uid: 543
+  - uid: 597
     components:
     - type: Transform
       pos: 20.5,26.5
       parent: 1
-  - uid: 544
+  - uid: 598
     components:
     - type: Transform
       pos: 20.5,28.5
       parent: 1
-  - uid: 545
+  - uid: 599
     components:
     - type: Transform
       pos: 20.5,27.5
       parent: 1
-  - uid: 546
+  - uid: 600
     components:
     - type: Transform
       pos: 20.5,29.5
       parent: 1
-  - uid: 547
+  - uid: 601
     components:
     - type: Transform
       pos: 20.5,30.5
       parent: 1
-  - uid: 548
+  - uid: 602
     components:
     - type: Transform
       pos: 20.5,31.5
       parent: 1
-  - uid: 549
+  - uid: 603
     components:
     - type: Transform
       pos: 20.5,32.5
       parent: 1
-  - uid: 550
+  - uid: 604
     components:
     - type: Transform
       pos: 20.5,33.5
       parent: 1
-  - uid: 551
+  - uid: 605
     components:
     - type: Transform
       pos: 20.5,34.5
       parent: 1
-  - uid: 552
+  - uid: 606
     components:
     - type: Transform
       pos: 20.5,35.5
       parent: 1
-  - uid: 553
+  - uid: 607
     components:
     - type: Transform
       pos: 20.5,36.5
       parent: 1
-  - uid: 554
+  - uid: 608
     components:
     - type: Transform
       pos: 20.5,37.5
       parent: 1
-  - uid: 555
+  - uid: 609
     components:
     - type: Transform
       pos: 20.5,38.5
       parent: 1
-  - uid: 556
+  - uid: 610
     components:
     - type: Transform
       pos: 20.5,39.5
       parent: 1
-  - uid: 557
+  - uid: 611
     components:
     - type: Transform
       pos: 20.5,40.5
       parent: 1
-  - uid: 558
+  - uid: 612
     components:
     - type: Transform
       pos: 20.5,41.5
       parent: 1
-  - uid: 559
+  - uid: 613
     components:
     - type: Transform
       pos: 20.5,42.5
       parent: 1
-  - uid: 560
+  - uid: 614
     components:
     - type: Transform
       pos: 20.5,43.5
       parent: 1
-  - uid: 561
+  - uid: 615
     components:
     - type: Transform
       pos: 21.5,45.5
       parent: 1
-  - uid: 562
+  - uid: 616
     components:
     - type: Transform
       pos: 20.5,45.5
       parent: 1
-  - uid: 563
+  - uid: 617
     components:
     - type: Transform
       pos: 20.5,44.5
       parent: 1
-  - uid: 564
+  - uid: 618
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 565
+  - uid: 619
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 566
+  - uid: 620
     components:
     - type: Transform
       pos: 3.5,16.5
       parent: 1
-  - uid: 567
+  - uid: 621
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 568
+  - uid: 622
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 569
+  - uid: 623
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 570
+  - uid: 624
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 571
+  - uid: 625
     components:
     - type: Transform
       pos: 3.5,18.5
       parent: 1
-  - uid: 572
+  - uid: 626
     components:
     - type: Transform
       pos: 3.5,19.5
       parent: 1
-  - uid: 573
+  - uid: 627
     components:
     - type: Transform
       pos: 3.5,20.5
       parent: 1
-  - uid: 574
+  - uid: 628
     components:
     - type: Transform
       pos: 3.5,21.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 575
+  - uid: 629
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 1
-  - uid: 576
+  - uid: 630
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 1
-  - uid: 577
+  - uid: 631
     components:
     - type: Transform
       pos: 4.5,23.5
       parent: 1
-  - uid: 578
+  - uid: 632
     components:
     - type: Transform
       pos: 21.5,45.5
       parent: 1
-  - uid: 579
+  - uid: 633
     components:
     - type: Transform
       pos: 21.5,44.5
       parent: 1
-  - uid: 580
+  - uid: 634
     components:
     - type: Transform
       pos: 22.5,44.5
       parent: 1
-  - uid: 581
+  - uid: 635
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 582
+  - uid: 636
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 583
+  - uid: 637
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 584
+  - uid: 638
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 585
+  - uid: 639
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 586
+  - uid: 640
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 587
+  - uid: 641
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 588
+  - uid: 642
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 589
+  - uid: 643
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 590
+  - uid: 644
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 591
+  - uid: 645
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 592
+  - uid: 646
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 593
+  - uid: 647
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 594
+  - uid: 648
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 595
+  - uid: 649
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 596
+  - uid: 650
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 1
-  - uid: 597
+  - uid: 651
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 598
+  - uid: 652
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 1
-  - uid: 599
+  - uid: 653
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 600
+  - uid: 654
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 601
+  - uid: 655
     components:
     - type: Transform
       pos: 8.5,-5.5
       parent: 1
-  - uid: 602
+  - uid: 656
     components:
     - type: Transform
       pos: 10.5,-5.5
       parent: 1
-  - uid: 603
+  - uid: 657
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 1
-  - uid: 604
+  - uid: 658
     components:
     - type: Transform
       pos: 10.5,-4.5
       parent: 1
-  - uid: 605
+  - uid: 659
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1
-  - uid: 606
+  - uid: 660
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 1
-  - uid: 607
+  - uid: 661
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 1
-  - uid: 608
+  - uid: 662
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
-  - uid: 609
+  - uid: 663
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
-  - uid: 610
+  - uid: 664
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 1
-  - uid: 611
+  - uid: 665
     components:
     - type: Transform
       pos: 15.5,0.5
       parent: 1
-  - uid: 612
+  - uid: 666
     components:
     - type: Transform
       pos: 15.5,-0.5
       parent: 1
-  - uid: 613
+  - uid: 667
     components:
     - type: Transform
       pos: 15.5,-1.5
       parent: 1
-  - uid: 614
+  - uid: 668
     components:
     - type: Transform
       pos: 15.5,-3.5
       parent: 1
-  - uid: 615
+  - uid: 669
     components:
     - type: Transform
       pos: 15.5,-2.5
       parent: 1
-  - uid: 616
+  - uid: 670
     components:
     - type: Transform
       pos: 15.5,-4.5
       parent: 1
-  - uid: 617
+  - uid: 671
     components:
     - type: Transform
       pos: 15.5,-5.5
       parent: 1
-  - uid: 618
+  - uid: 672
     components:
     - type: Transform
       pos: 15.5,-6.5
       parent: 1
-  - uid: 619
+  - uid: 673
     components:
     - type: Transform
       pos: 15.5,-7.5
       parent: 1
-  - uid: 620
+  - uid: 674
     components:
     - type: Transform
       pos: 16.5,-7.5
       parent: 1
-  - uid: 621
+  - uid: 675
     components:
     - type: Transform
       pos: 16.5,-8.5
       parent: 1
-  - uid: 622
+  - uid: 676
     components:
     - type: Transform
       pos: 16.5,-9.5
       parent: 1
-  - uid: 623
+  - uid: 677
     components:
     - type: Transform
       pos: 16.5,-10.5
       parent: 1
-  - uid: 624
+  - uid: 678
     components:
     - type: Transform
       pos: 16.5,-11.5
       parent: 1
-  - uid: 625
+  - uid: 679
     components:
     - type: Transform
       pos: 15.5,-11.5
       parent: 1
-  - uid: 626
+  - uid: 680
     components:
     - type: Transform
       pos: 14.5,-11.5
       parent: 1
-  - uid: 627
+  - uid: 681
     components:
     - type: Transform
       pos: 12.5,-11.5
       parent: 1
-  - uid: 628
+  - uid: 682
     components:
     - type: Transform
       pos: 11.5,-11.5
       parent: 1
-  - uid: 629
+  - uid: 683
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 1
-  - uid: 630
+  - uid: 684
     components:
     - type: Transform
       pos: 10.5,-11.5
       parent: 1
-  - uid: 631
+  - uid: 685
     components:
     - type: Transform
       pos: 10.5,-12.5
       parent: 1
-  - uid: 632
+  - uid: 686
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 1
-  - uid: 633
+  - uid: 687
     components:
     - type: Transform
       pos: 10.5,-14.5
       parent: 1
-  - uid: 634
+  - uid: 688
     components:
     - type: Transform
       pos: 10.5,-15.5
       parent: 1
-  - uid: 635
+  - uid: 689
     components:
     - type: Transform
       pos: 10.5,-16.5
       parent: 1
-  - uid: 636
+  - uid: 690
     components:
     - type: Transform
       pos: 7.5,-16.5
       parent: 1
-  - uid: 637
+  - uid: 691
     components:
     - type: Transform
       pos: 9.5,-16.5
       parent: 1
-  - uid: 638
+  - uid: 692
     components:
     - type: Transform
       pos: 8.5,-16.5
       parent: 1
-  - uid: 639
+  - uid: 693
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 640
+  - uid: 694
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 641
+  - uid: 695
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 642
+  - uid: 696
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 643
+  - uid: 697
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 644
+  - uid: 698
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 645
+  - uid: 699
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-9.5
       parent: 1
-  - uid: 646
+  - uid: 700
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 647
+  - uid: 701
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-7.5
       parent: 1
-  - uid: 648
+  - uid: 702
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,23.5
       parent: 1
-  - uid: 649
+  - uid: 703
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,23.5
       parent: 1
-  - uid: 650
+  - uid: 704
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4744,1437 +4758,1437 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 651
+  - uid: 705
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,12.5
       parent: 1
-  - uid: 652
+  - uid: 706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,9.5
       parent: 1
-  - uid: 653
+  - uid: 707
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,20.5
       parent: 1
-  - uid: 654
+  - uid: 708
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,17.5
       parent: 1
-  - uid: 655
+  - uid: 709
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,14.5
       parent: 1
-  - uid: 656
+  - uid: 710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-9.5
       parent: 1
-  - uid: 657
+  - uid: 711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-10.5
       parent: 1
-  - uid: 658
+  - uid: 712
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-11.5
       parent: 1
-  - uid: 659
+  - uid: 713
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-11.5
       parent: 1
-  - uid: 660
+  - uid: 714
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 661
+  - uid: 715
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-9.5
       parent: 1
-  - uid: 662
+  - uid: 716
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 1
-  - uid: 663
+  - uid: 717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 664
+  - uid: 718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
-  - uid: 665
+  - uid: 719
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-5.5
       parent: 1
-  - uid: 666
+  - uid: 720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-7.5
       parent: 1
-  - uid: 667
+  - uid: 721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-7.5
       parent: 1
-  - uid: 668
+  - uid: 722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,23.5
       parent: 1
-  - uid: 669
+  - uid: 723
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-9.5
       parent: 1
-  - uid: 670
+  - uid: 724
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-8.5
       parent: 1
-  - uid: 671
+  - uid: 725
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-8.5
       parent: 1
-  - uid: 672
+  - uid: 726
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-10.5
       parent: 1
-  - uid: 673
+  - uid: 727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-8.5
       parent: 1
-  - uid: 674
+  - uid: 728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-10.5
       parent: 1
-  - uid: 675
+  - uid: 729
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-9.5
       parent: 1
-  - uid: 676
+  - uid: 730
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-10.5
       parent: 1
-  - uid: 677
+  - uid: 731
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-8.5
       parent: 1
-  - uid: 678
+  - uid: 732
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-9.5
       parent: 1
-  - uid: 679
+  - uid: 733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-10.5
       parent: 1
-  - uid: 680
+  - uid: 734
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-8.5
       parent: 1
-  - uid: 681
+  - uid: 735
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-9.5
       parent: 1
-  - uid: 682
+  - uid: 736
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-10.5
       parent: 1
-  - uid: 683
+  - uid: 737
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-8.5
       parent: 1
-  - uid: 684
+  - uid: 738
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-9.5
       parent: 1
-  - uid: 685
+  - uid: 739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-10.5
       parent: 1
-  - uid: 686
+  - uid: 740
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-8.5
       parent: 1
-  - uid: 687
+  - uid: 741
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-9.5
       parent: 1
-  - uid: 688
+  - uid: 742
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-10.5
       parent: 1
-  - uid: 689
+  - uid: 743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,8.5
       parent: 1
-  - uid: 690
+  - uid: 744
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,10.5
       parent: 1
-  - uid: 691
+  - uid: 745
     components:
     - type: Transform
       pos: 10.5,17.5
       parent: 1
-  - uid: 692
+  - uid: 746
     components:
     - type: Transform
       pos: 10.5,20.5
       parent: 1
-  - uid: 693
+  - uid: 747
     components:
     - type: Transform
       pos: 10.5,23.5
       parent: 1
-  - uid: 694
+  - uid: 748
     components:
     - type: Transform
       pos: 11.5,20.5
       parent: 1
-  - uid: 695
+  - uid: 749
     components:
     - type: Transform
       pos: 11.5,23.5
       parent: 1
-  - uid: 696
+  - uid: 750
     components:
     - type: Transform
       pos: 11.5,14.5
       parent: 1
-  - uid: 697
+  - uid: 751
     components:
     - type: Transform
       pos: 10.5,14.5
       parent: 1
-  - uid: 698
+  - uid: 752
     components:
     - type: Transform
       pos: 11.5,17.5
       parent: 1
-  - uid: 699
+  - uid: 753
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,40.5
       parent: 1
-  - uid: 700
+  - uid: 754
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,40.5
       parent: 1
-  - uid: 701
+  - uid: 755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,23.5
       parent: 1
-  - uid: 702
+  - uid: 756
     components:
     - type: Transform
       pos: 22.5,34.5
       parent: 1
-  - uid: 703
+  - uid: 757
     components:
     - type: Transform
       pos: 21.5,30.5
       parent: 1
-  - uid: 704
+  - uid: 758
     components:
     - type: Transform
       pos: 21.5,39.5
       parent: 1
-  - uid: 705
+  - uid: 759
     components:
     - type: Transform
       pos: 21.5,31.5
       parent: 1
-  - uid: 706
+  - uid: 760
     components:
     - type: Transform
       pos: 22.5,30.5
       parent: 1
-  - uid: 707
+  - uid: 761
     components:
     - type: Transform
       pos: 22.5,32.5
       parent: 1
-  - uid: 708
+  - uid: 762
     components:
     - type: Transform
       pos: 21.5,37.5
       parent: 1
-  - uid: 709
+  - uid: 763
     components:
     - type: Transform
       pos: 22.5,31.5
       parent: 1
-  - uid: 711
+  - uid: 764
     components:
     - type: Transform
       pos: 21.5,32.5
       parent: 1
-  - uid: 712
+  - uid: 765
     components:
     - type: Transform
       pos: 21.5,38.5
       parent: 1
-  - uid: 713
+  - uid: 766
     components:
     - type: Transform
       pos: 21.5,40.5
       parent: 1
-  - uid: 714
+  - uid: 767
     components:
     - type: Transform
       pos: 21.5,35.5
       parent: 1
-  - uid: 715
+  - uid: 768
     components:
     - type: Transform
       pos: 21.5,34.5
       parent: 1
-  - uid: 716
+  - uid: 769
     components:
     - type: Transform
       pos: 21.5,36.5
       parent: 1
-  - uid: 717
+  - uid: 770
     components:
     - type: Transform
       pos: 8.5,22.5
       parent: 1
-  - uid: 718
+  - uid: 771
     components:
     - type: Transform
       pos: 8.5,23.5
       parent: 1
-  - uid: 719
+  - uid: 772
     components:
     - type: Transform
       pos: 12.5,22.5
       parent: 1
-  - uid: 720
+  - uid: 773
     components:
     - type: Transform
       pos: 12.5,23.5
       parent: 1
-  - uid: 723
+  - uid: 774
     components:
     - type: Transform
       pos: 17.5,29.5
       parent: 1
-  - uid: 725
+  - uid: 775
     components:
     - type: Transform
       pos: 17.5,30.5
       parent: 1
-  - uid: 726
+  - uid: 776
     components:
     - type: Transform
       pos: 17.5,31.5
       parent: 1
-  - uid: 727
+  - uid: 777
     components:
     - type: Transform
       pos: 17.5,32.5
       parent: 1
-  - uid: 728
+  - uid: 778
     components:
     - type: Transform
       pos: 17.5,33.5
       parent: 1
-  - uid: 729
+  - uid: 779
     components:
     - type: Transform
       pos: 17.5,34.5
       parent: 1
-  - uid: 730
+  - uid: 780
     components:
     - type: Transform
       pos: 17.5,35.5
       parent: 1
-  - uid: 731
+  - uid: 781
     components:
     - type: Transform
       pos: 17.5,36.5
       parent: 1
-  - uid: 732
+  - uid: 782
     components:
     - type: Transform
       pos: 17.5,37.5
       parent: 1
-  - uid: 733
+  - uid: 783
     components:
     - type: Transform
       pos: 17.5,38.5
       parent: 1
-  - uid: 734
+  - uid: 784
     components:
     - type: Transform
       pos: 17.5,39.5
       parent: 1
-  - uid: 735
+  - uid: 785
     components:
     - type: Transform
       pos: 17.5,40.5
       parent: 1
-  - uid: 736
+  - uid: 786
     components:
     - type: Transform
       pos: 17.5,41.5
       parent: 1
-  - uid: 737
+  - uid: 787
     components:
     - type: Transform
       pos: 17.5,42.5
       parent: 1
-  - uid: 738
+  - uid: 788
     components:
     - type: Transform
       pos: 17.5,43.5
       parent: 1
-  - uid: 739
+  - uid: 789
     components:
     - type: Transform
       pos: 17.5,44.5
       parent: 1
-  - uid: 740
+  - uid: 790
     components:
     - type: Transform
       pos: 17.5,45.5
       parent: 1
-  - uid: 741
+  - uid: 791
     components:
     - type: Transform
       pos: 0.5,41.5
       parent: 1
-  - uid: 742
+  - uid: 792
     components:
     - type: Transform
       pos: 0.5,40.5
       parent: 1
-  - uid: 743
+  - uid: 793
     components:
     - type: Transform
       pos: 0.5,39.5
       parent: 1
-  - uid: 744
+  - uid: 794
     components:
     - type: Transform
       pos: 0.5,38.5
       parent: 1
-  - uid: 745
+  - uid: 795
     components:
     - type: Transform
       pos: 0.5,36.5
       parent: 1
-  - uid: 746
+  - uid: 796
     components:
     - type: Transform
       pos: 0.5,37.5
       parent: 1
-  - uid: 747
+  - uid: 797
     components:
     - type: Transform
       pos: 0.5,35.5
       parent: 1
-  - uid: 748
+  - uid: 798
     components:
     - type: Transform
       pos: 0.5,34.5
       parent: 1
-  - uid: 749
+  - uid: 799
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 1
-  - uid: 750
+  - uid: 800
     components:
     - type: Transform
       pos: 0.5,32.5
       parent: 1
-  - uid: 751
+  - uid: 801
     components:
     - type: Transform
       pos: 0.5,31.5
       parent: 1
-  - uid: 752
+  - uid: 802
     components:
     - type: Transform
       pos: 0.5,30.5
       parent: 1
-  - uid: 753
+  - uid: 803
     components:
     - type: Transform
       pos: 0.5,29.5
       parent: 1
-  - uid: 761
+  - uid: 804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,14.5
       parent: 1
-  - uid: 762
+  - uid: 805
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,14.5
       parent: 1
-  - uid: 763
+  - uid: 806
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,14.5
       parent: 1
-  - uid: 764
+  - uid: 807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,15.5
       parent: 1
-  - uid: 765
+  - uid: 808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,16.5
       parent: 1
-  - uid: 766
+  - uid: 809
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,17.5
       parent: 1
-  - uid: 767
+  - uid: 810
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,18.5
       parent: 1
-  - uid: 768
+  - uid: 811
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,19.5
       parent: 1
-  - uid: 769
+  - uid: 812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,20.5
       parent: 1
-  - uid: 770
+  - uid: 813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,15.5
       parent: 1
-  - uid: 771
+  - uid: 814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,16.5
       parent: 1
-  - uid: 772
+  - uid: 815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,17.5
       parent: 1
-  - uid: 773
+  - uid: 816
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,18.5
       parent: 1
-  - uid: 774
+  - uid: 817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,19.5
       parent: 1
-  - uid: 775
+  - uid: 818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,20.5
       parent: 1
-  - uid: 776
+  - uid: 819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,15.5
       parent: 1
-  - uid: 777
+  - uid: 820
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,16.5
       parent: 1
-  - uid: 778
+  - uid: 821
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,17.5
       parent: 1
-  - uid: 779
+  - uid: 822
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,18.5
       parent: 1
-  - uid: 780
+  - uid: 823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,19.5
       parent: 1
-  - uid: 781
+  - uid: 824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,20.5
       parent: 1
-  - uid: 783
+  - uid: 825
     components:
     - type: Transform
       pos: -2.5,22.5
       parent: 1
-  - uid: 784
+  - uid: 826
     components:
     - type: Transform
       pos: -2.5,21.5
       parent: 1
-  - uid: 787
+  - uid: 827
     components:
     - type: Transform
       pos: -2.5,28.5
       parent: 1
-  - uid: 788
+  - uid: 828
     components:
     - type: Transform
       pos: -2.5,29.5
       parent: 1
-  - uid: 789
+  - uid: 829
     components:
     - type: Transform
       pos: -2.5,31.5
       parent: 1
-  - uid: 790
+  - uid: 830
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 1
-  - uid: 791
+  - uid: 831
     components:
     - type: Transform
       pos: -2.5,32.5
       parent: 1
-  - uid: 792
+  - uid: 832
     components:
     - type: Transform
       pos: -2.5,33.5
       parent: 1
-  - uid: 793
+  - uid: 833
     components:
     - type: Transform
       pos: -2.5,34.5
       parent: 1
-  - uid: 794
+  - uid: 834
     components:
     - type: Transform
       pos: -2.5,35.5
       parent: 1
-  - uid: 795
+  - uid: 835
     components:
     - type: Transform
       pos: -2.5,36.5
       parent: 1
-  - uid: 796
+  - uid: 836
     components:
     - type: Transform
       pos: -2.5,37.5
       parent: 1
-  - uid: 797
+  - uid: 837
     components:
     - type: Transform
       pos: -2.5,38.5
       parent: 1
-  - uid: 798
-    components:
-    - type: Transform
-      pos: -2.5,39.5
-      parent: 1
-  - uid: 799
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,19.5
-      parent: 1
-  - uid: 800
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,18.5
-      parent: 1
-  - uid: 801
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,15.5
-      parent: 1
-  - uid: 802
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,17.5
-      parent: 1
-  - uid: 803
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,16.5
-      parent: 1
-  - uid: 804
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,13.5
-      parent: 1
-  - uid: 805
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,14.5
-      parent: 1
-  - uid: 806
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,44.5
-      parent: 1
-  - uid: 807
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,44.5
-      parent: 1
-  - uid: 808
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,12.5
-      parent: 1
-  - uid: 809
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-16.5
-      parent: 1
-  - uid: 810
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-16.5
-      parent: 1
-  - uid: 811
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,-16.5
-      parent: 1
-  - uid: 812
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,-15.5
-      parent: 1
-  - uid: 813
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,-14.5
-      parent: 1
-  - uid: 814
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,-13.5
-      parent: 1
-  - uid: 815
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,7.5
-      parent: 1
-  - uid: 816
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-6.5
-      parent: 1
-  - uid: 817
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-5.5
-      parent: 1
-  - uid: 818
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-4.5
-      parent: 1
-  - uid: 819
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-3.5
-      parent: 1
-  - uid: 820
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-2.5
-      parent: 1
-  - uid: 821
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-1.5
-      parent: 1
-  - uid: 822
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-0.5
-      parent: 1
-  - uid: 823
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,0.5
-      parent: 1
-  - uid: 824
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,1.5
-      parent: 1
-  - uid: 825
-    components:
-    - type: Transform
-      pos: 7.5,1.5
-      parent: 1
-  - uid: 826
-    components:
-    - type: Transform
-      pos: 20.5,23.5
-      parent: 1
-  - uid: 827
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,12.5
-      parent: 1
-  - uid: 828
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,20.5
-      parent: 1
-  - uid: 829
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,12.5
-      parent: 1
-  - uid: 830
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,12.5
-      parent: 1
-  - uid: 831
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,12.5
-      parent: 1
-  - uid: 832
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,12.5
-      parent: 1
-  - uid: 833
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,11.5
-      parent: 1
-  - uid: 834
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,11.5
-      parent: 1
-  - uid: 835
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,11.5
-      parent: 1
-  - uid: 836
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,11.5
-      parent: 1
-  - uid: 837
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,11.5
-      parent: 1
   - uid: 838
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,12.5
+      pos: -2.5,39.5
       parent: 1
   - uid: 839
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 14.5,12.5
+      pos: 3.5,19.5
       parent: 1
   - uid: 840
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,12.5
+      pos: 3.5,18.5
       parent: 1
   - uid: 841
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,13.5
+      pos: 3.5,15.5
       parent: 1
   - uid: 842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,14.5
+      pos: 3.5,17.5
       parent: 1
   - uid: 843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,15.5
+      pos: 3.5,16.5
       parent: 1
   - uid: 844
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,16.5
+      pos: 3.5,13.5
       parent: 1
   - uid: 845
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,17.5
+      pos: 3.5,14.5
       parent: 1
   - uid: 846
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,18.5
+      rot: -1.5707963267948966 rad
+      pos: 21.5,44.5
       parent: 1
   - uid: 847
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,19.5
+      rot: -1.5707963267948966 rad
+      pos: 20.5,44.5
       parent: 1
   - uid: 848
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,20.5
+      pos: 12.5,12.5
       parent: 1
   - uid: 849
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,21.5
+      pos: 8.5,-16.5
       parent: 1
   - uid: 850
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,22.5
+      pos: 9.5,-16.5
       parent: 1
   - uid: 851
     components:
     - type: Transform
-      pos: 21.5,41.5
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-16.5
       parent: 1
   - uid: 852
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-15.5
+      parent: 1
+  - uid: 853
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-14.5
+      parent: 1
+  - uid: 854
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-13.5
+      parent: 1
+  - uid: 855
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 856
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-6.5
+      parent: 1
+  - uid: 857
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-5.5
+      parent: 1
+  - uid: 858
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-4.5
+      parent: 1
+  - uid: 859
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-3.5
+      parent: 1
+  - uid: 860
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-2.5
+      parent: 1
+  - uid: 861
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-1.5
+      parent: 1
+  - uid: 862
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-0.5
+      parent: 1
+  - uid: 863
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,0.5
+      parent: 1
+  - uid: 864
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,1.5
+      parent: 1
+  - uid: 865
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 866
+    components:
+    - type: Transform
+      pos: 20.5,23.5
+      parent: 1
+  - uid: 867
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 868
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,20.5
+      parent: 1
+  - uid: 869
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 870
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,12.5
+      parent: 1
+  - uid: 871
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 872
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 874
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,11.5
+      parent: 1
+  - uid: 876
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,11.5
+      parent: 1
+  - uid: 877
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,11.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,12.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,12.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,12.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,13.5
+      parent: 1
+  - uid: 882
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,14.5
+      parent: 1
+  - uid: 883
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,15.5
+      parent: 1
+  - uid: 884
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,16.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,17.5
+      parent: 1
+  - uid: 886
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,18.5
+      parent: 1
+  - uid: 887
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,19.5
+      parent: 1
+  - uid: 888
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,20.5
+      parent: 1
+  - uid: 889
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,21.5
+      parent: 1
+  - uid: 890
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,22.5
+      parent: 1
+  - uid: 891
+    components:
+    - type: Transform
+      pos: 21.5,41.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
       pos: 22.5,35.5
       parent: 1
-  - uid: 2266
+  - uid: 893
     components:
     - type: Transform
       pos: 3.5,29.5
       parent: 1
-  - uid: 2271
+  - uid: 894
     components:
     - type: Transform
       pos: 16.5,28.5
       parent: 1
-  - uid: 2272
+  - uid: 895
     components:
     - type: Transform
       pos: 17.5,28.5
       parent: 1
-  - uid: 2273
+  - uid: 896
     components:
     - type: Transform
       pos: 5.5,29.5
       parent: 1
-  - uid: 2274
+  - uid: 897
     components:
     - type: Transform
       pos: 6.5,29.5
       parent: 1
-  - uid: 2275
+  - uid: 898
     components:
     - type: Transform
       pos: 7.5,29.5
       parent: 1
-  - uid: 2276
+  - uid: 899
     components:
     - type: Transform
       pos: 8.5,29.5
       parent: 1
-  - uid: 2277
+  - uid: 900
     components:
     - type: Transform
       pos: 4.5,29.5
       parent: 1
-  - uid: 2278
+  - uid: 901
     components:
     - type: Transform
       pos: 9.5,29.5
       parent: 1
-  - uid: 2279
+  - uid: 902
     components:
     - type: Transform
       pos: 10.5,29.5
       parent: 1
-  - uid: 2280
+  - uid: 903
     components:
     - type: Transform
       pos: 11.5,29.5
       parent: 1
-  - uid: 2281
+  - uid: 904
     components:
     - type: Transform
       pos: 13.5,29.5
       parent: 1
-  - uid: 2282
+  - uid: 905
     components:
     - type: Transform
       pos: 12.5,29.5
       parent: 1
-  - uid: 2283
+  - uid: 906
     components:
     - type: Transform
       pos: 14.5,29.5
       parent: 1
-  - uid: 2284
+  - uid: 907
     components:
     - type: Transform
       pos: 15.5,29.5
       parent: 1
-  - uid: 2285
+  - uid: 908
     components:
     - type: Transform
       pos: 16.5,29.5
       parent: 1
-  - uid: 2287
+  - uid: 909
     components:
     - type: Transform
       pos: 2.5,29.5
       parent: 1
-  - uid: 2288
+  - uid: 910
     components:
     - type: Transform
       pos: 1.5,29.5
       parent: 1
-  - uid: 2289
+  - uid: 911
     components:
     - type: Transform
       pos: 8.5,26.5
       parent: 1
-  - uid: 2290
+  - uid: 912
     components:
     - type: Transform
       pos: 9.5,26.5
       parent: 1
-  - uid: 2291
+  - uid: 913
     components:
     - type: Transform
       pos: 11.5,26.5
       parent: 1
-  - uid: 2292
+  - uid: 914
     components:
     - type: Transform
       pos: 10.5,26.5
       parent: 1
-  - uid: 2293
+  - uid: 915
     components:
     - type: Transform
       pos: 12.5,26.5
       parent: 1
-  - uid: 2294
+  - uid: 916
     components:
     - type: Transform
       pos: 8.5,24.5
       parent: 1
-  - uid: 2295
+  - uid: 917
     components:
     - type: Transform
       pos: 8.5,25.5
       parent: 1
-  - uid: 2296
+  - uid: 918
     components:
     - type: Transform
       pos: 8.5,27.5
       parent: 1
-  - uid: 2297
+  - uid: 919
     components:
     - type: Transform
       pos: 8.5,28.5
       parent: 1
-  - uid: 2298
+  - uid: 920
     components:
     - type: Transform
       pos: 12.5,28.5
       parent: 1
-  - uid: 2299
+  - uid: 921
     components:
     - type: Transform
       pos: 12.5,27.5
       parent: 1
-  - uid: 2300
+  - uid: 922
     components:
     - type: Transform
       pos: 12.5,25.5
       parent: 1
-  - uid: 2301
+  - uid: 923
     components:
     - type: Transform
       pos: 12.5,24.5
       parent: 1
-  - uid: 2308
+  - uid: 924
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,20.5
       parent: 1
-  - uid: 2309
+  - uid: 925
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,21.5
       parent: 1
-  - uid: 2310
+  - uid: 926
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,22.5
       parent: 1
-  - uid: 2311
+  - uid: 927
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,23.5
       parent: 1
-  - uid: 2315
+  - uid: 928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,27.5
       parent: 1
-  - uid: 2316
+  - uid: 929
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,28.5
       parent: 1
-  - uid: 2317
+  - uid: 930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,29.5
       parent: 1
-  - uid: 2318
+  - uid: 931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,30.5
       parent: 1
-  - uid: 2319
+  - uid: 932
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,31.5
       parent: 1
-  - uid: 2320
+  - uid: 933
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,32.5
       parent: 1
-  - uid: 2321
+  - uid: 934
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,33.5
       parent: 1
-  - uid: 2322
+  - uid: 935
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,34.5
       parent: 1
-  - uid: 2323
+  - uid: 936
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,35.5
       parent: 1
-  - uid: 2324
+  - uid: 937
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,36.5
       parent: 1
-  - uid: 2325
+  - uid: 938
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,37.5
       parent: 1
-  - uid: 2326
+  - uid: 939
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,38.5
       parent: 1
-  - uid: 2327
+  - uid: 940
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,39.5
       parent: 1
-  - uid: 2328
+  - uid: 941
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,40.5
       parent: 1
-  - uid: 2329
+  - uid: 942
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,21.5
       parent: 1
-  - uid: 2330
+  - uid: 943
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,22.5
       parent: 1
-  - uid: 2331
+  - uid: 944
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,23.5
       parent: 1
-  - uid: 2332
+  - uid: 945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,24.5
       parent: 1
-  - uid: 2333
+  - uid: 946
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,25.5
       parent: 1
-  - uid: 2334
+  - uid: 947
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,26.5
       parent: 1
-  - uid: 2335
+  - uid: 948
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,27.5
       parent: 1
-  - uid: 2336
+  - uid: 949
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,28.5
       parent: 1
-  - uid: 2337
+  - uid: 950
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,29.5
       parent: 1
-  - uid: 2338
+  - uid: 951
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,30.5
       parent: 1
-  - uid: 2339
+  - uid: 952
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,31.5
       parent: 1
-  - uid: 2340
+  - uid: 953
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,32.5
       parent: 1
-  - uid: 2341
+  - uid: 954
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,33.5
       parent: 1
-  - uid: 2342
+  - uid: 955
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,34.5
       parent: 1
-  - uid: 2343
+  - uid: 956
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,35.5
       parent: 1
-  - uid: 2344
+  - uid: 957
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,36.5
       parent: 1
-  - uid: 2345
+  - uid: 958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,37.5
       parent: 1
-  - uid: 2346
+  - uid: 959
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,38.5
       parent: 1
-  - uid: 2347
+  - uid: 960
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,39.5
       parent: 1
-  - uid: 2348
+  - uid: 961
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6182,13 +6196,13 @@ entities:
       parent: 1
 - proto: Chair
   entities:
-  - uid: 853
+  - uid: 962
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,1.5
       parent: 1
-  - uid: 854
+  - uid: 963
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6196,24 +6210,24 @@ entities:
       parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 855
+  - uid: 964
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.586738,18.171726
       parent: 1
-  - uid: 856
+  - uid: 965
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.922675,15.499851
       parent: 1
-  - uid: 857
+  - uid: 966
     components:
     - type: Transform
       pos: 14.71955,19.648289
       parent: 1
-  - uid: 858
+  - uid: 967
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6221,7 +6235,7 @@ entities:
       parent: 1
 - proto: ChairOfficeLight
   entities:
-  - uid: 859
+  - uid: 968
     components:
     - type: Transform
       rot: -1.1683739513188436 rad
@@ -6233,7 +6247,7 @@ entities:
       prevFixedRotation: True
 - proto: ChairPilotSeat
   entities:
-  - uid: 860
+  - uid: 969
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6241,13 +6255,13 @@ entities:
       parent: 1
 - proto: ChairWood
   entities:
-  - uid: 861
+  - uid: 970
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.6237402,-1.6370986
       parent: 1
-  - uid: 862
+  - uid: 971
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6255,21 +6269,21 @@ entities:
       parent: 1
 - proto: CheckerBoard
   entities:
-  - uid: 863
+  - uid: 972
     components:
     - type: Transform
       pos: 13.656163,17.602304
       parent: 1
 - proto: ChemistryHotplate
   entities:
-  - uid: 864
+  - uid: 973
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
 - proto: ChessBoard
   entities:
-  - uid: 865
+  - uid: 974
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6277,7 +6291,7 @@ entities:
       parent: 1
 - proto: CircularShieldBase
   entities:
-  - uid: 866
+  - uid: 975
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6309,7 +6323,7 @@ entities:
         ShieldFixture:
           shape: !type:PhysShapeCircle
             radius: 0
-            position: 10.878864,6.874728
+            position: 10.98699,10.087136
           mask: []
           layer:
           - BulletImpassable
@@ -6317,37 +6331,36 @@ entities:
           hard: False
           restitution: 0
           friction: 0.4
-    - type: ApcPowerReceiver
-      powerLoad: 0
 - proto: CircularShieldConsole
   entities:
-  - uid: 868
+  - uid: 977
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        866:
-        - CircularShieldConsoleSender: CircularShieldConsoleReceiver
+        975:
+        - - CircularShieldConsoleSender
+          - CircularShieldConsoleReceiver
     - type: ApcPowerReceiver
       powerLoad: 5
 - proto: ClothingHeadHelmetEVA
   entities:
-  - uid: 869
+  - uid: 978
     components:
     - type: Transform
       pos: 13.398351,19.547617
       parent: 1
 - proto: ComfyChair
   entities:
-  - uid: 870
+  - uid: 979
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,1.5
       parent: 1
-  - uid: 871
+  - uid: 980
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6355,7 +6368,7 @@ entities:
       parent: 1
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 872
+  - uid: 981
     components:
     - type: Transform
       pos: 11.5,2.5
@@ -6363,10 +6376,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 873
+  - uid: 982
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6375,10 +6387,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerRadar
   entities:
-  - uid: 874
+  - uid: 983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6387,10 +6398,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerStationRecords
   entities:
-  - uid: 875
+  - uid: 984
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6399,10 +6409,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerTabletopAdvancedRadar
   entities:
-  - uid: 876
+  - uid: 985
     components:
     - type: Transform
       pos: 9.5,2.5
@@ -6410,10 +6419,9 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerTabletopCrewMonitoring
   entities:
-  - uid: 877
+  - uid: 986
     components:
     - type: Transform
       pos: 8.5,2.5
@@ -6421,806 +6429,790 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
 - proto: ComputerTabletopShuttleAntag
   entities:
-  - uid: 878
+  - uid: 987
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
-    - type: ShuttleConsoleLock
-      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-      startingCharge: 0
-    - type: DeviceLinkSource
-      linkedPorts: {}
-      lastSignals: {}
-      ports:
-      - device-button-1
-      - device-button-2
-      - device-button-3
-      - device-button-4
-      - device-button-5
-      - device-button-6
-      - device-button-7
-      - device-button-8
 - proto: ConveyorBelt
   entities:
-  - uid: 879
+  - uid: 988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,6.5
       parent: 1
-  - uid: 880
-    components:
-    - type: Transform
-      pos: 16.5,6.5
-      parent: 1
-  - uid: 881
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,4.5
-      parent: 1
-  - uid: 882
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,5.5
-      parent: 1
-  - uid: 883
-    components:
-    - type: Transform
-      pos: 16.5,4.5
-      parent: 1
-  - uid: 884
-    components:
-    - type: Transform
-      pos: 16.5,5.5
-      parent: 1
-  - uid: 885
-    components:
-    - type: Transform
-      pos: 17.5,-9.5
-      parent: 1
-  - uid: 886
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-13.5
-      parent: 1
-  - uid: 887
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-8.5
-      parent: 1
-  - uid: 888
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-12.5
-      parent: 1
-  - uid: 889
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,0.5
-      parent: 1
-  - uid: 890
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,3.5
-      parent: 1
-  - uid: 891
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-3.5
-      parent: 1
-  - uid: 892
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,2.5
-      parent: 1
-  - uid: 893
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-5.5
-      parent: 1
-  - uid: 894
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-12.5
-      parent: 1
-  - uid: 895
-    components:
-    - type: Transform
-      pos: 17.5,-5.5
-      parent: 1
-  - uid: 896
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-6.5
-      parent: 1
-  - uid: 897
-    components:
-    - type: Transform
-      pos: 17.5,0.5
-      parent: 1
-  - uid: 898
-    components:
-    - type: Transform
-      pos: 12.5,-13.5
-      parent: 1
-  - uid: 899
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-0.5
-      parent: 1
-  - uid: 900
-    components:
-    - type: Transform
-      pos: 17.5,1.5
-      parent: 1
-  - uid: 901
-    components:
-    - type: Transform
-      pos: 17.5,2.5
-      parent: 1
-  - uid: 902
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,3.5
-      parent: 1
-  - uid: 903
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-4.5
-      parent: 1
-  - uid: 904
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-2.5
-      parent: 1
-  - uid: 905
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-13.5
-      parent: 1
-  - uid: 906
-    components:
-    - type: Transform
-      pos: 17.5,-4.5
-      parent: 1
-  - uid: 907
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-1.5
-      parent: 1
-  - uid: 908
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,1.5
-      parent: 1
-  - uid: 909
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-7.5
-      parent: 1
-  - uid: 910
-    components:
-    - type: Transform
-      pos: 17.5,-0.5
-      parent: 1
-  - uid: 911
-    components:
-    - type: Transform
-      pos: 17.5,-2.5
-      parent: 1
-  - uid: 912
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-10.5
-      parent: 1
-  - uid: 913
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-9.5
-      parent: 1
-  - uid: 914
-    components:
-    - type: Transform
-      pos: 17.5,-1.5
-      parent: 1
-  - uid: 915
-    components:
-    - type: Transform
-      pos: 17.5,-3.5
-      parent: 1
-  - uid: 916
-    components:
-    - type: Transform
-      pos: 16.5,3.5
-      parent: 1
-  - uid: 917
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,2.5
-      parent: 1
-  - uid: 918
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-12.5
-      parent: 1
-  - uid: 919
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-13.5
-      parent: 1
-  - uid: 920
-    components:
-    - type: Transform
-      pos: 11.5,-14.5
-      parent: 1
-  - uid: 921
-    components:
-    - type: Transform
-      pos: 11.5,-15.5
-      parent: 1
-  - uid: 922
-    components:
-    - type: Transform
-      pos: 11.5,-17.5
-      parent: 1
-  - uid: 923
-    components:
-    - type: Transform
-      pos: 11.5,-16.5
-      parent: 1
-  - uid: 924
-    components:
-    - type: Transform
-      pos: 11.5,-18.5
-      parent: 1
-  - uid: 925
-    components:
-    - type: Transform
-      pos: 11.5,-19.5
-      parent: 1
-  - uid: 926
-    components:
-    - type: Transform
-      pos: 11.5,-20.5
-      parent: 1
-  - uid: 927
-    components:
-    - type: Transform
-      pos: 11.5,-21.5
-      parent: 1
-  - uid: 928
-    components:
-    - type: Transform
-      pos: 11.5,-22.5
-      parent: 1
-  - uid: 929
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-22.5
-      parent: 1
-  - uid: 930
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-21.5
-      parent: 1
-  - uid: 931
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-20.5
-      parent: 1
-  - uid: 932
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-19.5
-      parent: 1
-  - uid: 933
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-17.5
-      parent: 1
-  - uid: 934
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-18.5
-      parent: 1
-  - uid: 935
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-16.5
-      parent: 1
-  - uid: 936
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,-15.5
-      parent: 1
-  - uid: 937
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-14.5
-      parent: 1
-  - uid: 938
-    components:
-    - type: Transform
-      pos: 13.5,-12.5
-      parent: 1
-  - uid: 939
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-12.5
-      parent: 1
-  - uid: 940
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 17.5,-13.5
-      parent: 1
-  - uid: 941
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-13.5
-      parent: 1
-  - uid: 942
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-13.5
-      parent: 1
-  - uid: 943
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-14.5
-      parent: 1
-  - uid: 944
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,-15.5
-      parent: 1
-  - uid: 945
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-12.5
-      parent: 1
-  - uid: 946
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-14.5
-      parent: 1
-  - uid: 947
-    components:
-    - type: Transform
-      pos: 17.5,-6.5
-      parent: 1
-  - uid: 948
-    components:
-    - type: Transform
-      pos: 17.5,-7.5
-      parent: 1
-  - uid: 949
-    components:
-    - type: Transform
-      pos: 17.5,-8.5
-      parent: 1
-  - uid: 950
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-11.5
-      parent: 1
-  - uid: 951
-    components:
-    - type: Transform
-      pos: 17.5,-11.5
-      parent: 1
-  - uid: 952
-    components:
-    - type: Transform
-      pos: 17.5,-10.5
-      parent: 1
-  - uid: 953
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,14.5
-      parent: 1
-  - uid: 954
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,8.5
-      parent: 1
-  - uid: 955
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,7.5
-      parent: 1
-  - uid: 956
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,9.5
-      parent: 1
-  - uid: 957
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,10.5
-      parent: 1
-  - uid: 958
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,11.5
-      parent: 1
-  - uid: 959
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,21.5
-      parent: 1
-  - uid: 960
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,22.5
-      parent: 1
-  - uid: 961
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,23.5
-      parent: 1
-  - uid: 962
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,24.5
-      parent: 1
-  - uid: 963
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,25.5
-      parent: 1
-  - uid: 964
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,26.5
-      parent: 1
-  - uid: 965
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,27.5
-      parent: 1
-  - uid: 966
-    components:
-    - type: Transform
-      pos: 21.5,33.5
-      parent: 1
-  - uid: 967
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,29.5
-      parent: 1
-  - uid: 968
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,21.5
-      parent: 1
-  - uid: 969
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,21.5
-      parent: 1
-  - uid: 970
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,21.5
-      parent: 1
-  - uid: 971
-    components:
-    - type: Transform
-      pos: 16.5,11.5
-      parent: 1
-  - uid: 972
-    components:
-    - type: Transform
-      pos: 16.5,10.5
-      parent: 1
-  - uid: 973
-    components:
-    - type: Transform
-      pos: 16.5,9.5
-      parent: 1
-  - uid: 974
-    components:
-    - type: Transform
-      pos: 16.5,8.5
-      parent: 1
-  - uid: 975
-    components:
-    - type: Transform
-      pos: 16.5,7.5
-      parent: 1
-  - uid: 976
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,13.5
-      parent: 1
-  - uid: 977
-    components:
-    - type: Transform
-      pos: 21.5,23.5
-      parent: 1
-  - uid: 978
-    components:
-    - type: Transform
-      pos: 21.5,24.5
-      parent: 1
-  - uid: 979
-    components:
-    - type: Transform
-      pos: 21.5,25.5
-      parent: 1
-  - uid: 980
-    components:
-    - type: Transform
-      pos: 21.5,26.5
-      parent: 1
-  - uid: 981
-    components:
-    - type: Transform
-      pos: 21.5,27.5
-      parent: 1
-  - uid: 982
-    components:
-    - type: Transform
-      pos: 21.5,29.5
-      parent: 1
-  - uid: 983
-    components:
-    - type: Transform
-      pos: 21.5,28.5
-      parent: 1
-  - uid: 984
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,33.5
-      parent: 1
-  - uid: 985
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,28.5
-      parent: 1
-  - uid: 986
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,22.5
-      parent: 1
-  - uid: 987
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,22.5
-      parent: 1
-  - uid: 988
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,22.5
-      parent: 1
   - uid: 989
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,12.5
+      pos: 16.5,6.5
       parent: 1
   - uid: 990
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,15.5
+      pos: 17.5,4.5
       parent: 1
   - uid: 991
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,17.5
+      pos: 17.5,5.5
       parent: 1
   - uid: 992
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,16.5
+      pos: 16.5,4.5
       parent: 1
   - uid: 993
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,18.5
+      pos: 16.5,5.5
       parent: 1
   - uid: 994
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,19.5
+      pos: 17.5,-9.5
       parent: 1
   - uid: 995
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 18.5,20.5
+      pos: 18.5,-13.5
       parent: 1
   - uid: 996
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-8.5
+      parent: 1
+  - uid: 997
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-12.5
+      parent: 1
+  - uid: 998
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,0.5
+      parent: 1
+  - uid: 999
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,3.5
+      parent: 1
+  - uid: 1000
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-3.5
+      parent: 1
+  - uid: 1001
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,2.5
+      parent: 1
+  - uid: 1002
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-5.5
+      parent: 1
+  - uid: 1003
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-12.5
+      parent: 1
+  - uid: 1004
+    components:
+    - type: Transform
+      pos: 17.5,-5.5
+      parent: 1
+  - uid: 1005
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-6.5
+      parent: 1
+  - uid: 1006
+    components:
+    - type: Transform
+      pos: 17.5,0.5
+      parent: 1
+  - uid: 1007
+    components:
+    - type: Transform
+      pos: 12.5,-13.5
+      parent: 1
+  - uid: 1008
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-0.5
+      parent: 1
+  - uid: 1009
+    components:
+    - type: Transform
+      pos: 17.5,1.5
+      parent: 1
+  - uid: 1010
+    components:
+    - type: Transform
+      pos: 17.5,2.5
+      parent: 1
+  - uid: 1011
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,3.5
+      parent: 1
+  - uid: 1012
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-4.5
+      parent: 1
+  - uid: 1013
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-2.5
+      parent: 1
+  - uid: 1014
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-13.5
+      parent: 1
+  - uid: 1015
+    components:
+    - type: Transform
+      pos: 17.5,-4.5
+      parent: 1
+  - uid: 1016
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-1.5
+      parent: 1
+  - uid: 1017
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,1.5
+      parent: 1
+  - uid: 1018
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-7.5
+      parent: 1
+  - uid: 1019
+    components:
+    - type: Transform
+      pos: 17.5,-0.5
+      parent: 1
+  - uid: 1020
+    components:
+    - type: Transform
+      pos: 17.5,-2.5
+      parent: 1
+  - uid: 1021
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-10.5
+      parent: 1
+  - uid: 1022
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-9.5
+      parent: 1
+  - uid: 1023
+    components:
+    - type: Transform
+      pos: 17.5,-1.5
+      parent: 1
+  - uid: 1024
+    components:
+    - type: Transform
+      pos: 17.5,-3.5
+      parent: 1
+  - uid: 1025
+    components:
+    - type: Transform
+      pos: 16.5,3.5
+      parent: 1
+  - uid: 1026
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,2.5
+      parent: 1
+  - uid: 1027
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-12.5
+      parent: 1
+  - uid: 1028
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-13.5
+      parent: 1
+  - uid: 1029
+    components:
+    - type: Transform
+      pos: 11.5,-14.5
+      parent: 1
+  - uid: 1030
+    components:
+    - type: Transform
+      pos: 11.5,-15.5
+      parent: 1
+  - uid: 1031
+    components:
+    - type: Transform
+      pos: 11.5,-17.5
+      parent: 1
+  - uid: 1032
+    components:
+    - type: Transform
+      pos: 11.5,-16.5
+      parent: 1
+  - uid: 1033
+    components:
+    - type: Transform
+      pos: 11.5,-18.5
+      parent: 1
+  - uid: 1034
+    components:
+    - type: Transform
+      pos: 11.5,-19.5
+      parent: 1
+  - uid: 1035
+    components:
+    - type: Transform
+      pos: 11.5,-20.5
+      parent: 1
+  - uid: 1036
+    components:
+    - type: Transform
+      pos: 11.5,-21.5
+      parent: 1
+  - uid: 1037
+    components:
+    - type: Transform
+      pos: 11.5,-22.5
+      parent: 1
+  - uid: 1038
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-22.5
+      parent: 1
+  - uid: 1039
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-21.5
+      parent: 1
+  - uid: 1040
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-20.5
+      parent: 1
+  - uid: 1041
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-19.5
+      parent: 1
+  - uid: 1042
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-17.5
+      parent: 1
+  - uid: 1043
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-18.5
+      parent: 1
+  - uid: 1044
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-16.5
+      parent: 1
+  - uid: 1045
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-15.5
+      parent: 1
+  - uid: 1046
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-14.5
+      parent: 1
+  - uid: 1047
+    components:
+    - type: Transform
+      pos: 13.5,-12.5
+      parent: 1
+  - uid: 1048
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-12.5
+      parent: 1
+  - uid: 1049
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-13.5
+      parent: 1
+  - uid: 1050
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-13.5
+      parent: 1
+  - uid: 1051
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-13.5
+      parent: 1
+  - uid: 1052
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-14.5
+      parent: 1
+  - uid: 1053
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-15.5
+      parent: 1
+  - uid: 1054
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-12.5
+      parent: 1
+  - uid: 1055
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-14.5
+      parent: 1
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: 17.5,-6.5
+      parent: 1
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: 17.5,-7.5
+      parent: 1
+  - uid: 1058
+    components:
+    - type: Transform
+      pos: 17.5,-8.5
+      parent: 1
+  - uid: 1059
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-11.5
+      parent: 1
+  - uid: 1060
+    components:
+    - type: Transform
+      pos: 17.5,-11.5
+      parent: 1
+  - uid: 1061
+    components:
+    - type: Transform
+      pos: 17.5,-10.5
+      parent: 1
+  - uid: 1062
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,14.5
+      parent: 1
+  - uid: 1063
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,8.5
+      parent: 1
+  - uid: 1064
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,7.5
+      parent: 1
+  - uid: 1065
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,9.5
+      parent: 1
+  - uid: 1066
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,10.5
+      parent: 1
+  - uid: 1067
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,11.5
+      parent: 1
+  - uid: 1068
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,21.5
+      parent: 1
+  - uid: 1069
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,22.5
+      parent: 1
+  - uid: 1070
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,23.5
+      parent: 1
+  - uid: 1071
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,24.5
+      parent: 1
+  - uid: 1072
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,25.5
+      parent: 1
+  - uid: 1073
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,26.5
+      parent: 1
+  - uid: 1074
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,27.5
+      parent: 1
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: 21.5,33.5
+      parent: 1
+  - uid: 1076
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,29.5
+      parent: 1
+  - uid: 1077
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,21.5
+      parent: 1
+  - uid: 1078
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,21.5
+      parent: 1
+  - uid: 1079
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,21.5
+      parent: 1
+  - uid: 1080
+    components:
+    - type: Transform
+      pos: 16.5,11.5
+      parent: 1
+  - uid: 1081
+    components:
+    - type: Transform
+      pos: 16.5,10.5
+      parent: 1
+  - uid: 1082
+    components:
+    - type: Transform
+      pos: 16.5,9.5
+      parent: 1
+  - uid: 1083
+    components:
+    - type: Transform
+      pos: 16.5,8.5
+      parent: 1
+  - uid: 1084
+    components:
+    - type: Transform
+      pos: 16.5,7.5
+      parent: 1
+  - uid: 1085
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,13.5
+      parent: 1
+  - uid: 1086
+    components:
+    - type: Transform
+      pos: 21.5,23.5
+      parent: 1
+  - uid: 1087
+    components:
+    - type: Transform
+      pos: 21.5,24.5
+      parent: 1
+  - uid: 1088
+    components:
+    - type: Transform
+      pos: 21.5,25.5
+      parent: 1
+  - uid: 1089
+    components:
+    - type: Transform
+      pos: 21.5,26.5
+      parent: 1
+  - uid: 1090
+    components:
+    - type: Transform
+      pos: 21.5,27.5
+      parent: 1
+  - uid: 1091
+    components:
+    - type: Transform
+      pos: 21.5,29.5
+      parent: 1
+  - uid: 1092
+    components:
+    - type: Transform
+      pos: 21.5,28.5
+      parent: 1
+  - uid: 1093
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,33.5
+      parent: 1
+  - uid: 1094
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,28.5
+      parent: 1
+  - uid: 1095
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,22.5
+      parent: 1
+  - uid: 1096
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,22.5
+      parent: 1
+  - uid: 1097
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,22.5
+      parent: 1
+  - uid: 1098
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,12.5
+      parent: 1
+  - uid: 1099
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,15.5
+      parent: 1
+  - uid: 1100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,17.5
+      parent: 1
+  - uid: 1101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,16.5
+      parent: 1
+  - uid: 1102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,18.5
+      parent: 1
+  - uid: 1103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,19.5
+      parent: 1
+  - uid: 1104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,20.5
+      parent: 1
+  - uid: 1105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,21.5
       parent: 1
-  - uid: 997
+  - uid: 1106
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,18.5
       parent: 1
-  - uid: 998
+  - uid: 1107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,22.5
       parent: 1
-  - uid: 999
+  - uid: 1108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,19.5
       parent: 1
-  - uid: 1000
+  - uid: 1109
     components:
     - type: Transform
       pos: 17.5,20.5
       parent: 1
-  - uid: 1001
+  - uid: 1110
     components:
     - type: Transform
       pos: 17.5,21.5
       parent: 1
-  - uid: 1002
+  - uid: 1111
     components:
     - type: Transform
       pos: 17.5,22.5
       parent: 1
-  - uid: 1003
+  - uid: 1112
     components:
     - type: Transform
       pos: 16.5,19.5
       parent: 1
-  - uid: 1004
+  - uid: 1113
     components:
     - type: Transform
       pos: 16.5,18.5
       parent: 1
-  - uid: 1005
+  - uid: 1114
     components:
     - type: Transform
       pos: 16.5,17.5
       parent: 1
-  - uid: 1006
+  - uid: 1115
     components:
     - type: Transform
       pos: 16.5,16.5
       parent: 1
-  - uid: 1007
+  - uid: 1116
     components:
     - type: Transform
       pos: 16.5,15.5
       parent: 1
-  - uid: 1008
+  - uid: 1117
     components:
     - type: Transform
       pos: 16.5,14.5
       parent: 1
-  - uid: 1009
+  - uid: 1118
     components:
     - type: Transform
       pos: 16.5,13.5
       parent: 1
-  - uid: 1010
+  - uid: 1119
     components:
     - type: Transform
       pos: 16.5,12.5
       parent: 1
 - proto: DrinkBeerBottleFull
   entities:
-  - uid: 1011
+  - uid: 1120
     components:
     - type: Transform
       pos: 3.5065527,1.995714
       parent: 1
-  - uid: 1012
+  - uid: 1121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5768652,0.87071395
       parent: 1
-  - uid: 1013
+  - uid: 1122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5690527,0.56602645
       parent: 1
-  - uid: 1014
+  - uid: 1123
     components:
     - type: Transform
       pos: 13.492101,18.750742
       parent: 1
 - proto: EngineeringTechFab
   entities:
-  - uid: 1015
+  - uid: 1124
     components:
     - type: Transform
       pos: 22.5,40.5
       parent: 1
 - proto: ExplorersLootRadar
   entities:
-  - uid: 1016
+  - uid: 1125
     components:
     - type: MetaData
       name: Radar Dish
@@ -7229,14 +7221,14 @@ entities:
       parent: 1
 - proto: FaxMachineShipAntag
   entities:
-  - uid: 1017
+  - uid: 1126
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 1018
+  - uid: 1127
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7244,19 +7236,19 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1026
-      - 1027
-      - 1025
-      - 1024
-      - 1023
-      - 1034
-      - 1033
-      - 1031
-      - 1032
-      - 1030
-      - 1028
-      - 1029
-  - uid: 1019
+      - 1135
+      - 1136
+      - 1134
+      - 1133
+      - 1132
+      - 1143
+      - 1142
+      - 1140
+      - 1141
+      - 1139
+      - 1137
+      - 1138
+  - uid: 1128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7264,24 +7256,24 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1034
-      - 1033
-      - 1035
-      - 1036
-  - uid: 1020
+      - 1143
+      - 1142
+      - 1144
+      - 1145
+  - uid: 1129
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1035
-      - 1036
-      - 1037
-      - 1038
-      - 1040
-      - 1041
-  - uid: 1021
+      - 1144
+      - 1145
+      - 1146
+      - 1147
+      - 1149
+      - 1150
+  - uid: 1130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7289,9 +7281,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1039
-      - 1038
-  - uid: 1022
+      - 1148
+      - 1147
+  - uid: 1131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7299,12 +7291,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1031
-      - 1037
-      - 1032
+      - 1140
+      - 1146
+      - 1141
 - proto: Firelock
   entities:
-  - uid: 1023
+  - uid: 1132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7312,9 +7304,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-  - uid: 1024
+      - 6
+      - 1127
+  - uid: 1133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7322,9 +7314,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-  - uid: 1025
+      - 6
+      - 1127
+  - uid: 1134
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7332,9 +7324,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-  - uid: 1026
+      - 6
+      - 1127
+  - uid: 1135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7342,9 +7334,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-  - uid: 1027
+      - 6
+      - 1127
+  - uid: 1136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7352,9 +7344,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-  - uid: 1028
+      - 6
+      - 1127
+  - uid: 1137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7362,9 +7354,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-  - uid: 1029
+      - 6
+      - 1127
+  - uid: 1138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7372,9 +7364,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-  - uid: 1030
+      - 6
+      - 1127
+  - uid: 1139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7382,9 +7374,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-  - uid: 1031
+      - 6
+      - 1127
+  - uid: 1140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7392,11 +7384,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-      - 8
-      - 1022
-  - uid: 1032
+      - 6
+      - 1127
+      - 9
+      - 1131
+  - uid: 1141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7404,11 +7396,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-      - 8
-      - 1022
-  - uid: 1033
+      - 6
+      - 1127
+      - 9
+      - 1131
+  - uid: 1142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7416,11 +7408,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-      - 1019
       - 6
-  - uid: 1034
+      - 1127
+      - 1128
+      - 7
+  - uid: 1143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7428,11 +7420,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 1018
-      - 1019
       - 6
-  - uid: 1035
+      - 1127
+      - 1128
+      - 7
+  - uid: 1144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7440,11 +7432,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1019
-      - 6
+      - 1128
       - 7
-      - 1020
-  - uid: 1036
+      - 8
+      - 1129
+  - uid: 1145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7452,11 +7444,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1019
-      - 6
+      - 1128
       - 7
-      - 1020
-  - uid: 1037
+      - 8
+      - 1129
+  - uid: 1146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7464,11 +7456,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
+      - 9
+      - 1131
       - 8
-      - 1022
-      - 7
-      - 1020
-  - uid: 1038
+      - 1129
+  - uid: 1147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7476,11 +7468,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1021
-      - 9
-      - 7
-      - 1020
-  - uid: 1039
+      - 1130
+      - 10
+      - 8
+      - 1129
+  - uid: 1148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7488,9 +7480,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1021
-      - 9
-  - uid: 1040
+      - 1130
+      - 10
+  - uid: 1149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7498,9 +7490,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 1020
-  - uid: 1041
+      - 8
+      - 1129
+  - uid: 1150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7508,11 +7500,11 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 1020
+      - 8
+      - 1129
 - proto: GasMixer
   entities:
-  - uid: 1042
+  - uid: 1151
     components:
     - type: Transform
       pos: 14.5,-7.5
@@ -7524,7 +7516,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPassiveVent
   entities:
-  - uid: 1043
+  - uid: 1152
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7532,7 +7524,7 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 1044
+  - uid: 1153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7540,13 +7532,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1045
+  - uid: 1154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-7.5
       parent: 1
-  - uid: 1046
+  - uid: 1155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7554,7 +7546,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1047
+  - uid: 1156
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7562,7 +7554,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1048
+  - uid: 1157
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7570,7 +7562,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1049
+  - uid: 1158
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7578,7 +7570,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1050
+  - uid: 1159
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7586,14 +7578,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1051
+  - uid: 1160
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1052
+  - uid: 1161
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7601,7 +7593,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1053
+  - uid: 1162
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7609,14 +7601,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1054
+  - uid: 1163
     components:
     - type: Transform
       pos: 17.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1055
+  - uid: 1164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7624,7 +7616,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1056
+  - uid: 1165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7632,7 +7624,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1057
+  - uid: 1166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7640,21 +7632,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1058
+  - uid: 1167
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1059
+  - uid: 1168
     components:
     - type: Transform
       pos: 16.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1060
+  - uid: 1169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7662,7 +7654,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1061
+  - uid: 1170
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7670,14 +7662,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1062
+  - uid: 1171
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1063
+  - uid: 1172
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7685,21 +7677,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1064
+  - uid: 1173
     components:
     - type: Transform
       pos: 13.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1065
+  - uid: 1174
     components:
     - type: Transform
       pos: 13.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1066
+  - uid: 1175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7707,14 +7699,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1067
+  - uid: 1176
     components:
     - type: Transform
       pos: 10.5,-17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1068
+  - uid: 1177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7722,7 +7714,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1069
+  - uid: 1178
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7730,7 +7722,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1070
+  - uid: 1179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7740,14 +7732,14 @@ entities:
       color: '#990000FF'
 - proto: GasPipeFourway
   entities:
-  - uid: 1071
+  - uid: 1180
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1072
+  - uid: 1181
     components:
     - type: Transform
       pos: 14.5,-9.5
@@ -7756,7 +7748,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeSensorDistribution
   entities:
-  - uid: 1073
+  - uid: 1182
     components:
     - type: Transform
       pos: 14.5,-8.5
@@ -7765,7 +7757,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeSensorWaste
   entities:
-  - uid: 1074
+  - uid: 1183
     components:
     - type: Transform
       pos: 8.5,-19.5
@@ -7774,7 +7766,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 1075
+  - uid: 1184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7782,70 +7774,70 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1076
+  - uid: 1185
     components:
     - type: Transform
       pos: 14.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1077
+  - uid: 1186
     components:
     - type: Transform
       pos: 15.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1078
+  - uid: 1187
     components:
     - type: Transform
       pos: 15.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1079
+  - uid: 1188
     components:
     - type: Transform
       pos: 15.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1080
+  - uid: 1189
     components:
     - type: Transform
       pos: 15.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1081
+  - uid: 1190
     components:
     - type: Transform
       pos: 15.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1082
+  - uid: 1191
     components:
     - type: Transform
       pos: 15.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1083
+  - uid: 1192
     components:
     - type: Transform
       pos: 15.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1084
+  - uid: 1193
     components:
     - type: Transform
       pos: 15.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1085
+  - uid: 1194
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7853,7 +7845,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1086
+  - uid: 1195
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7861,133 +7853,133 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1087
+  - uid: 1196
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1088
+  - uid: 1197
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1089
+  - uid: 1198
     components:
     - type: Transform
       pos: 9.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1090
+  - uid: 1199
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1091
+  - uid: 1200
     components:
     - type: Transform
       pos: 9.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1092
+  - uid: 1201
     components:
     - type: Transform
       pos: 9.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1093
+  - uid: 1202
     components:
     - type: Transform
       pos: 9.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1094
+  - uid: 1203
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1095
+  - uid: 1204
     components:
     - type: Transform
       pos: 9.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1096
+  - uid: 1205
     components:
     - type: Transform
       pos: 9.5,-17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1097
+  - uid: 1206
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1098
+  - uid: 1207
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1099
+  - uid: 1208
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1100
+  - uid: 1209
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1101
+  - uid: 1210
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1102
+  - uid: 1211
     components:
     - type: Transform
       pos: 8.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1103
+  - uid: 1212
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1104
+  - uid: 1213
     components:
     - type: Transform
       pos: 8.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1105
+  - uid: 1214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7995,7 +7987,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1106
+  - uid: 1215
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8003,7 +7995,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1107
+  - uid: 1216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8011,7 +8003,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1108
+  - uid: 1217
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8019,49 +8011,49 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1109
+  - uid: 1218
     components:
     - type: Transform
       pos: 16.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1110
+  - uid: 1219
     components:
     - type: Transform
       pos: 16.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1111
+  - uid: 1220
     components:
     - type: Transform
       pos: 16.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1112
+  - uid: 1221
     components:
     - type: Transform
       pos: 16.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1113
+  - uid: 1222
     components:
     - type: Transform
       pos: 16.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1114
+  - uid: 1223
     components:
     - type: Transform
       pos: 16.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1115
+  - uid: 1224
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8069,7 +8061,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1116
+  - uid: 1225
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8077,7 +8069,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1117
+  - uid: 1226
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8085,7 +8077,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1118
+  - uid: 1227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8093,7 +8085,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1119
+  - uid: 1228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8101,7 +8093,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1120
+  - uid: 1229
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8109,7 +8101,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1121
+  - uid: 1230
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8117,7 +8109,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1122
+  - uid: 1231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8125,7 +8117,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1123
+  - uid: 1232
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8133,7 +8125,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1124
+  - uid: 1233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8141,7 +8133,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1125
+  - uid: 1234
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8149,7 +8141,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1126
+  - uid: 1235
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8157,7 +8149,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1127
+  - uid: 1236
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8165,7 +8157,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1128
+  - uid: 1237
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8173,7 +8165,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1129
+  - uid: 1238
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8181,7 +8173,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1130
+  - uid: 1239
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8189,7 +8181,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1131
+  - uid: 1240
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8197,7 +8189,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1132
+  - uid: 1241
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8205,14 +8197,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1133
+  - uid: 1242
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1134
+  - uid: 1243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8220,7 +8212,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1135
+  - uid: 1244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8228,7 +8220,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1136
+  - uid: 1245
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8236,7 +8228,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1137
+  - uid: 1246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8244,7 +8236,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1138
+  - uid: 1247
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8252,7 +8244,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1139
+  - uid: 1248
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8260,7 +8252,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1140
+  - uid: 1249
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8268,7 +8260,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1141
+  - uid: 1250
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8276,7 +8268,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1142
+  - uid: 1251
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8284,7 +8276,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1143
+  - uid: 1252
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8292,7 +8284,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1144
+  - uid: 1253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8300,7 +8292,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1145
+  - uid: 1254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8308,7 +8300,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1146
+  - uid: 1255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8316,7 +8308,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1147
+  - uid: 1256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8324,7 +8316,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1148
+  - uid: 1257
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8332,7 +8324,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1149
+  - uid: 1258
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8340,7 +8332,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1150
+  - uid: 1259
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8348,7 +8340,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1151
+  - uid: 1260
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8356,7 +8348,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1152
+  - uid: 1261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8364,7 +8356,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1153
+  - uid: 1262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8372,7 +8364,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1154
+  - uid: 1263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8380,7 +8372,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1155
+  - uid: 1264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8388,7 +8380,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1156
+  - uid: 1265
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8396,7 +8388,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1157
+  - uid: 1266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8404,7 +8396,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1158
+  - uid: 1267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8412,7 +8404,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1159
+  - uid: 1268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8420,7 +8412,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1160
+  - uid: 1269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8428,7 +8420,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1161
+  - uid: 1270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8436,7 +8428,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1162
+  - uid: 1271
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8444,7 +8436,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1163
+  - uid: 1272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8452,7 +8444,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1164
+  - uid: 1273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8460,7 +8452,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1165
+  - uid: 1274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8468,7 +8460,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1166
+  - uid: 1275
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8476,7 +8468,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1167
+  - uid: 1276
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8484,7 +8476,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1168
+  - uid: 1277
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8492,7 +8484,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1169
+  - uid: 1278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8500,56 +8492,56 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1170
+  - uid: 1279
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1171
+  - uid: 1280
     components:
     - type: Transform
       pos: 16.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1172
+  - uid: 1281
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1173
+  - uid: 1282
     components:
     - type: Transform
       pos: 15.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1174
+  - uid: 1283
     components:
     - type: Transform
       pos: 15.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1175
+  - uid: 1284
     components:
     - type: Transform
       pos: 15.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1176
+  - uid: 1285
     components:
     - type: Transform
       pos: 15.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1177
+  - uid: 1286
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8557,49 +8549,49 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1178
+  - uid: 1287
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1179
+  - uid: 1288
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1180
+  - uid: 1289
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1181
+  - uid: 1290
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1182
+  - uid: 1291
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1183
+  - uid: 1292
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1184
+  - uid: 1293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8607,7 +8599,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1185
+  - uid: 1294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8615,7 +8607,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1186
+  - uid: 1295
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8623,7 +8615,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1187
+  - uid: 1296
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8631,7 +8623,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1188
+  - uid: 1297
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8639,7 +8631,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1189
+  - uid: 1298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8647,7 +8639,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1190
+  - uid: 1299
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8655,7 +8647,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1191
+  - uid: 1300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8663,7 +8655,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1192
+  - uid: 1301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8673,7 +8665,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 1195
+  - uid: 1302
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8681,7 +8673,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1196
+  - uid: 1303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8689,21 +8681,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1197
+  - uid: 1304
     components:
     - type: Transform
       pos: 9.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1198
+  - uid: 1305
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1199
+  - uid: 1306
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8711,7 +8703,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1200
+  - uid: 1307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8719,7 +8711,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1201
+  - uid: 1308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8727,7 +8719,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1202
+  - uid: 1309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8735,7 +8727,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1203
+  - uid: 1310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8743,7 +8735,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1204
+  - uid: 1311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8751,7 +8743,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1205
+  - uid: 1312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8759,7 +8751,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1206
+  - uid: 1313
     components:
     - type: Transform
       pos: 12.5,-8.5
@@ -8768,19 +8760,19 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 1207
+  - uid: 1314
     components:
     - type: Transform
       pos: 13.5,-6.5
       parent: 1
-  - uid: 1208
+  - uid: 1315
     components:
     - type: Transform
       pos: 14.5,-6.5
       parent: 1
 - proto: GasPressurePumpOnMax
   entities:
-  - uid: 1209
+  - uid: 1316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8792,7 +8784,7 @@ entities:
       color: '#990000FF'
 - proto: GasVentPump
   entities:
-  - uid: 1210
+  - uid: 1317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8800,10 +8792,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 6
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1211
+  - uid: 1318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8811,10 +8803,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 6
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1212
+  - uid: 1319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8822,10 +8814,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 6
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1213
+  - uid: 1320
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8833,10 +8825,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 6
+      - 7
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1214
+  - uid: 1321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8844,20 +8836,20 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1215
+  - uid: 1322
     components:
     - type: Transform
       pos: 11.5,-2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 8
+      - 9
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1216
+  - uid: 1323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8865,17 +8857,17 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 8
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1217
+  - uid: 1324
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1218
+  - uid: 1325
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8885,7 +8877,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 1219
+  - uid: 1326
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8893,10 +8885,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 6
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1220
+  - uid: 1327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8904,10 +8896,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 6
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1221
+  - uid: 1328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8915,10 +8907,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 6
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1222
+  - uid: 1329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8926,10 +8918,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 6
+      - 7
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1223
+  - uid: 1330
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8937,20 +8929,20 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 10
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1224
+  - uid: 1331
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 8
+      - 9
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1225
+  - uid: 1332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8958,17 +8950,17 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 8
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1226
+  - uid: 1333
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1227
+  - uid: 1334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8978,687 +8970,687 @@ entities:
       color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 2173
+  - uid: 1335
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 1228
+  - uid: 1336
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 1
-  - uid: 1229
+  - uid: 1337
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 1230
+  - uid: 1338
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 1231
+  - uid: 1339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-10.5
       parent: 1
-  - uid: 1232
+  - uid: 1340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 1
-  - uid: 1233
+  - uid: 1341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 1
-  - uid: 1234
+  - uid: 1342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-8.5
       parent: 1
-  - uid: 1235
+  - uid: 1343
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-7.5
       parent: 1
-  - uid: 1236
+  - uid: 1344
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-6.5
       parent: 1
-  - uid: 1237
+  - uid: 1345
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-5.5
       parent: 1
-  - uid: 1238
+  - uid: 1346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-4.5
       parent: 1
-  - uid: 1239
+  - uid: 1347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
-  - uid: 1240
+  - uid: 1348
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-0.5
       parent: 1
-  - uid: 1241
+  - uid: 1349
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,0.5
       parent: 1
-  - uid: 1242
+  - uid: 1350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 1
-  - uid: 1243
+  - uid: 1351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 1
-  - uid: 1244
+  - uid: 1352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,3.5
       parent: 1
-  - uid: 1245
+  - uid: 1353
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
-  - uid: 1246
+  - uid: 1354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 1247
+  - uid: 1355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
-  - uid: 1248
+  - uid: 1356
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
-  - uid: 1249
+  - uid: 1357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-8.5
       parent: 1
-  - uid: 1250
+  - uid: 1358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-6.5
       parent: 1
-  - uid: 1251
+  - uid: 1359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-7.5
       parent: 1
-  - uid: 1252
+  - uid: 1360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-5.5
       parent: 1
-  - uid: 1253
+  - uid: 1361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-4.5
       parent: 1
-  - uid: 1254
+  - uid: 1362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-3.5
       parent: 1
-  - uid: 1255
+  - uid: 1363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-2.5
       parent: 1
-  - uid: 1256
+  - uid: 1364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-1.5
       parent: 1
-  - uid: 1257
+  - uid: 1365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-0.5
       parent: 1
-  - uid: 1258
+  - uid: 1366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,0.5
       parent: 1
-  - uid: 1259
+  - uid: 1367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,1.5
       parent: 1
-  - uid: 1260
+  - uid: 1368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,2.5
       parent: 1
-  - uid: 1261
+  - uid: 1369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,3.5
       parent: 1
-  - uid: 1262
+  - uid: 1370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,5.5
       parent: 1
-  - uid: 1263
+  - uid: 1371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,3.5
       parent: 1
-  - uid: 1264
+  - uid: 1372
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,1.5
       parent: 1
-  - uid: 1265
+  - uid: 1373
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-0.5
       parent: 1
-  - uid: 1266
+  - uid: 1374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-4.5
       parent: 1
-  - uid: 1267
+  - uid: 1375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-6.5
       parent: 1
-  - uid: 1268
+  - uid: 1376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-8.5
       parent: 1
-  - uid: 1269
+  - uid: 1377
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-10.5
       parent: 1
-  - uid: 1270
+  - uid: 1378
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 1271
+  - uid: 1379
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 1272
+  - uid: 1380
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 1273
+  - uid: 1381
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 1274
+  - uid: 1382
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 1275
+  - uid: 1383
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 1276
+  - uid: 1384
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 1
-  - uid: 1277
+  - uid: 1385
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 1278
+  - uid: 1386
     components:
     - type: Transform
       pos: 12.5,5.5
       parent: 1
-  - uid: 1279
+  - uid: 1387
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
-  - uid: 1280
+  - uid: 1388
     components:
     - type: Transform
       pos: 13.5,5.5
       parent: 1
-  - uid: 1281
+  - uid: 1389
     components:
     - type: Transform
       pos: 13.5,6.5
       parent: 1
-  - uid: 1282
+  - uid: 1390
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 1283
+  - uid: 1391
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 1
-  - uid: 1284
+  - uid: 1392
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 1
-  - uid: 1285
+  - uid: 1393
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 1286
+  - uid: 1394
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 1287
+  - uid: 1395
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 1288
+  - uid: 1396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,16.5
       parent: 1
-  - uid: 1289
+  - uid: 1397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,17.5
       parent: 1
-  - uid: 1290
+  - uid: 1398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,18.5
       parent: 1
-  - uid: 1291
+  - uid: 1399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,16.5
       parent: 1
-  - uid: 1292
+  - uid: 1400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,17.5
       parent: 1
-  - uid: 1293
+  - uid: 1401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,18.5
       parent: 1
-  - uid: 1294
+  - uid: 1402
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,14.5
       parent: 1
-  - uid: 1295
+  - uid: 1403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,12.5
       parent: 1
-  - uid: 1296
+  - uid: 1404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,14.5
       parent: 1
-  - uid: 1297
+  - uid: 1405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,12.5
       parent: 1
-  - uid: 1299
+  - uid: 1406
     components:
     - type: Transform
       pos: 0.5,48.5
       parent: 1
-  - uid: 1301
+  - uid: 1407
     components:
     - type: Transform
       pos: -1.5,45.5
       parent: 1
-  - uid: 1304
+  - uid: 1408
     components:
     - type: Transform
       pos: -1.5,46.5
       parent: 1
-  - uid: 1306
+  - uid: 1409
     components:
     - type: Transform
       pos: 18.5,49.5
       parent: 1
-  - uid: 1307
+  - uid: 1410
     components:
     - type: Transform
       pos: 0.5,46.5
       parent: 1
-  - uid: 1308
+  - uid: 1411
     components:
     - type: Transform
       pos: 0.5,47.5
       parent: 1
-  - uid: 1317
+  - uid: 1412
     components:
     - type: Transform
       pos: 4.5,-19.5
       parent: 1
-  - uid: 1318
+  - uid: 1413
     components:
     - type: Transform
       pos: 3.5,-18.5
       parent: 1
-  - uid: 1319
+  - uid: 1414
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
-  - uid: 1320
+  - uid: 1415
     components:
     - type: Transform
       pos: 15.5,-20.5
       parent: 1
-  - uid: 1321
+  - uid: 1416
     components:
     - type: Transform
       pos: 16.5,-19.5
       parent: 1
-  - uid: 1322
+  - uid: 1417
     components:
     - type: Transform
       pos: 17.5,-18.5
       parent: 1
-  - uid: 1323
+  - uid: 1418
     components:
     - type: Transform
       pos: 18.5,-17.5
       parent: 1
-  - uid: 1436
+  - uid: 1419
     components:
     - type: Transform
       pos: -2.5,24.5
       parent: 1
-  - uid: 1449
+  - uid: 1420
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 1
-  - uid: 2174
+  - uid: 1421
     components:
     - type: Transform
       pos: -3.5,24.5
       parent: 1
-  - uid: 2248
+  - uid: 1422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,15.5
       parent: 1
-  - uid: 2351
+  - uid: 1423
     components:
     - type: Transform
       pos: -2.5,25.5
       parent: 1
-  - uid: 2366
+  - uid: 1424
     components:
     - type: Transform
       pos: -3.5,49.5
       parent: 1
-  - uid: 2367
+  - uid: 1425
     components:
     - type: Transform
       pos: -3.5,50.5
       parent: 1
-  - uid: 2368
+  - uid: 1426
     components:
     - type: Transform
       pos: -3.5,51.5
       parent: 1
-  - uid: 2375
+  - uid: 1427
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,15.5
       parent: 1
-  - uid: 2392
+  - uid: 1428
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-15.5
       parent: 1
-  - uid: 2393
+  - uid: 1429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-15.5
       parent: 1
-  - uid: 2394
+  - uid: 1430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,15.5
       parent: 1
-  - uid: 2395
+  - uid: 1431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,15.5
       parent: 1
-  - uid: 2396
+  - uid: 1432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,15.5
       parent: 1
-  - uid: 2399
+  - uid: 1433
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,15.5
       parent: 1
-  - uid: 2461
+  - uid: 1434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,48.5
       parent: 1
-  - uid: 2462
+  - uid: 1435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,48.5
       parent: 1
-  - uid: 2463
+  - uid: 1436
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,49.5
       parent: 1
-  - uid: 2464
+  - uid: 1437
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,50.5
       parent: 1
-  - uid: 2465
+  - uid: 1438
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,51.5
       parent: 1
-  - uid: 2466
+  - uid: 1439
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,52.5
       parent: 1
-  - uid: 2467
+  - uid: 1440
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,53.5
       parent: 1
-  - uid: 2468
+  - uid: 1441
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,53.5
       parent: 1
-  - uid: 2469
+  - uid: 1442
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,54.5
       parent: 1
-  - uid: 2470
+  - uid: 1443
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,54.5
       parent: 1
-  - uid: 2471
+  - uid: 1444
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,55.5
       parent: 1
-  - uid: 2472
+  - uid: 1445
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,52.5
       parent: 1
-  - uid: 2473
+  - uid: 1446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,53.5
       parent: 1
-  - uid: 2474
+  - uid: 1447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,54.5
       parent: 1
-  - uid: 2475
+  - uid: 1448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,55.5
       parent: 1
-  - uid: 2476
+  - uid: 1449
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,56.5
       parent: 1
-  - uid: 2477
+  - uid: 1450
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,50.5
       parent: 1
-  - uid: 2478
+  - uid: 1451
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,51.5
       parent: 1
-  - uid: 2479
+  - uid: 1452
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,52.5
       parent: 1
-  - uid: 2480
+  - uid: 1453
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,53.5
       parent: 1
-  - uid: 2481
+  - uid: 1454
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,54.5
       parent: 1
-  - uid: 2483
+  - uid: 1455
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9666,274 +9658,274 @@ entities:
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 1324
+  - uid: 1456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-3.5
       parent: 1
-  - uid: 1325
+  - uid: 1457
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 1326
+  - uid: 1458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-6.5
       parent: 1
-  - uid: 1327
+  - uid: 1459
     components:
     - type: Transform
       pos: -8.5,1.5
       parent: 1
-  - uid: 1328
+  - uid: 1460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-9.5
       parent: 1
-  - uid: 1329
+  - uid: 1461
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
-  - uid: 1330
+  - uid: 1462
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-3.5
       parent: 1
-  - uid: 1331
+  - uid: 1463
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,-1.5
       parent: 1
-  - uid: 1332
+  - uid: 1464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,4.5
       parent: 1
-  - uid: 1333
+  - uid: 1465
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,1.5
       parent: 1
-  - uid: 1334
+  - uid: 1466
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-6.5
       parent: 1
-  - uid: 1335
+  - uid: 1467
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-9.5
       parent: 1
-  - uid: 1336
+  - uid: 1468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 1
-  - uid: 1337
+  - uid: 1469
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,5.5
       parent: 1
-  - uid: 1338
+  - uid: 1470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,3.5
       parent: 1
-  - uid: 1339
+  - uid: 1471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 1340
+  - uid: 1472
     components:
     - type: Transform
       pos: 11.5,5.5
       parent: 1
-  - uid: 1341
+  - uid: 1473
     components:
     - type: Transform
       pos: 12.5,6.5
       parent: 1
-  - uid: 1342
+  - uid: 1474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 1
-  - uid: 1344
+  - uid: 1475
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,13.5
       parent: 1
-  - uid: 1345
+  - uid: 1476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 1
-  - uid: 1347
+  - uid: 1477
     components:
     - type: Transform
       pos: 21.5,13.5
       parent: 1
-  - uid: 1348
+  - uid: 1478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,15.5
       parent: 1
-  - uid: 1349
+  - uid: 1479
     components:
     - type: Transform
       pos: 20.5,15.5
       parent: 1
-  - uid: 1350
+  - uid: 1480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 1351
+  - uid: 1481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 1352
+  - uid: 1482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,11.5
       parent: 1
-  - uid: 1353
+  - uid: 1483
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,11.5
       parent: 1
-  - uid: 1354
+  - uid: 1484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-19.5
       parent: 1
-  - uid: 1355
+  - uid: 1485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-18.5
       parent: 1
-  - uid: 1356
+  - uid: 1486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-21.5
       parent: 1
-  - uid: 1357
+  - uid: 1487
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-20.5
       parent: 1
-  - uid: 1358
+  - uid: 1488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-19.5
       parent: 1
-  - uid: 1359
+  - uid: 1489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-18.5
       parent: 1
-  - uid: 1360
+  - uid: 1490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-21.5
       parent: 1
-  - uid: 2252
+  - uid: 1491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,15.5
       parent: 1
-  - uid: 2253
+  - uid: 1492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,15.5
       parent: 1
-  - uid: 2254
+  - uid: 1493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 1
-  - uid: 2255
+  - uid: 1494
     components:
     - type: Transform
       pos: 22.5,16.5
       parent: 1
-  - uid: 2256
+  - uid: 1495
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,16.5
       parent: 1
-  - uid: 2257
+  - uid: 1496
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,14.5
       parent: 1
-  - uid: 2390
+  - uid: 1497
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-14.5
       parent: 1
-  - uid: 2391
+  - uid: 1498
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-14.5
       parent: 1
-  - uid: 2460
+  - uid: 1499
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,47.5
       parent: 1
-  - uid: 2482
+  - uid: 1500
     components:
     - type: Transform
       pos: 23.5,50.5
       parent: 1
-  - uid: 2484
+  - uid: 1501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,48.5
       parent: 1
-  - uid: 2485
+  - uid: 1502
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9941,70 +9933,61 @@ entities:
       parent: 1
 - proto: GunneryServerHigh
   entities:
-  - uid: 1361
+  - uid: 1503
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
     - type: Battery
-      startingCharge: 460.66727
+      startingCharge: 0
     - type: ApcPowerReceiver
       powerLoad: 20
-    - type: ApcPowerReceiverBattery
-      enabled: True
 - proto: GyroscopeSecurity
   entities:
-  - uid: 1362
+  - uid: 1504
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 1363
+  - uid: 1505
     components:
     - type: Transform
       pos: 5.5,-10.5
       parent: 1
-  - uid: 1364
+  - uid: 1506
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-- proto: HeadSkeleton
-  entities:
-  - uid: 1365
-    components:
-    - type: Transform
-      pos: 13.984288,19.383554
-      parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 1366
+  - uid: 1507
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 1367
+  - uid: 1508
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
 - proto: LockerSyndicatePersonal
   entities:
-  - uid: 1368
+  - uid: 1509
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 1369
+  - uid: 1510
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
 - proto: LockerWallMaterialsFuelAmeJarFilled
   entities:
-  - uid: 1370
+  - uid: 1511
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10012,239 +9995,229 @@ entities:
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 1371
+  - uid: 1512
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 1
-- proto: Magazine7.62x39mmFMJ
-  entities:
-  - uid: 1372
-    components:
-    - type: Transform
-      pos: 13.740284,-4.4032993
-      parent: 1
-  - uid: 1373
-    components:
-    - type: Transform
-      pos: 13.318409,-4.4657993
-      parent: 1
-  - uid: 1374
-    components:
-    - type: Transform
-      pos: 13.505909,-4.4657993
-      parent: 1
 - proto: MaterialReclaimer
   entities:
-  - uid: 2500
+  - uid: 1513
     components:
     - type: Transform
       pos: 22.5,41.5
       parent: 1
 - proto: MercenaryTechFab
   entities:
-  - uid: 1375
+  - uid: 1514
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
 - proto: NFHolopadShipAntag
   entities:
-  - uid: 1376
+  - uid: 1515
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
-- proto: OreBox
+- proto: NFMagnetBoxOre
   entities:
-  - uid: 1377
+  - uid: 1516
     components:
     - type: Transform
       pos: -0.5,41.5
       parent: 1
-  - uid: 1378
+  - uid: 1517
     components:
     - type: Transform
       pos: 0.5,36.5
       parent: 1
-  - uid: 1379
+  - uid: 1518
     components:
     - type: Transform
       pos: 0.5,34.5
       parent: 1
-  - uid: 1380
+  - uid: 1519
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 1
+- proto: NFWeaponRifleAssaultSm
+  entities:
+  - uid: 2489
+    components:
+    - type: Transform
+      pos: 13.549298,-4.6064243
+      parent: 1
 - proto: OreProcessor
   entities:
-  - uid: 1381
+  - uid: 1520
     components:
     - type: Transform
       pos: 22.5,38.5
       parent: 1
 - proto: PlastitaniumWindow
   entities:
-  - uid: 782
+  - uid: 1521
     components:
     - type: Transform
       pos: -2.5,24.5
       parent: 1
-  - uid: 1315
+  - uid: 1522
     components:
     - type: Transform
       pos: -3.5,24.5
       parent: 1
-  - uid: 1316
+  - uid: 1523
     components:
     - type: Transform
       pos: -2.5,25.5
       parent: 1
-  - uid: 1382
+  - uid: 1524
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,3.5
       parent: 1
-  - uid: 1383
+  - uid: 1525
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,3.5
       parent: 1
-  - uid: 1384
+  - uid: 1526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,3.5
       parent: 1
-  - uid: 1385
+  - uid: 1527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,3.5
       parent: 1
-  - uid: 1386
+  - uid: 1528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,3.5
       parent: 1
-  - uid: 1387
+  - uid: 1529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,4.5
       parent: 1
-  - uid: 1388
+  - uid: 1530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,4.5
       parent: 1
-  - uid: 1389
+  - uid: 1531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,4.5
       parent: 1
-  - uid: 1390
+  - uid: 1532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,4.5
       parent: 1
-  - uid: 1391
+  - uid: 1533
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,5.5
       parent: 1
-  - uid: 1392
+  - uid: 1534
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,4.5
       parent: 1
-  - uid: 1393
+  - uid: 1535
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 1
-  - uid: 1394
+  - uid: 1536
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,5.5
       parent: 1
-  - uid: 1395
+  - uid: 1537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,6.5
       parent: 1
-  - uid: 1396
+  - uid: 1538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,5.5
       parent: 1
-  - uid: 1397
+  - uid: 1539
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,4.5
       parent: 1
-  - uid: 1398
+  - uid: 1540
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,5.5
       parent: 1
-  - uid: 1399
+  - uid: 1541
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,6.5
       parent: 1
-  - uid: 1450
+  - uid: 1542
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 1
 - proto: PlastitaniumWindowDiagonal
   entities:
-  - uid: 1400
+  - uid: 1543
     components:
     - type: Transform
       pos: 11.5,5.5
       parent: 1
-  - uid: 1401
+  - uid: 1544
     components:
     - type: Transform
       pos: 12.5,6.5
       parent: 1
-  - uid: 1402
+  - uid: 1545
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 1
-  - uid: 1403
+  - uid: 1546
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,5.5
       parent: 1
-  - uid: 1404
+  - uid: 1547
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 1405
+  - uid: 1548
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10252,24 +10225,24 @@ entities:
       parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 2497
+  - uid: 1549
     components:
     - type: Transform
       pos: 24.5,35.5
       parent: 1
-  - uid: 2498
+  - uid: 1550
     components:
     - type: Transform
       pos: 24.5,31.5
       parent: 1
-  - uid: 2499
+  - uid: 1551
     components:
     - type: Transform
       pos: 24.5,43.5
       parent: 1
 - proto: PoweredlightCyan
   entities:
-  - uid: 1406
+  - uid: 1552
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10277,48 +10250,48 @@ entities:
       parent: 1
 - proto: PoweredlightExterior
   entities:
-  - uid: 1407
+  - uid: 1553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,37.5
       parent: 1
-  - uid: 1408
+  - uid: 1554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,29.5
       parent: 1
-  - uid: 1409
+  - uid: 1555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,33.5
       parent: 1
-  - uid: 1410
+  - uid: 1556
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,24.5
       parent: 1
-  - uid: 1411
+  - uid: 1557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,41.5
       parent: 1
-  - uid: 1412
+  - uid: 1558
     components:
     - type: Transform
       pos: 19.5,44.5
       parent: 1
-  - uid: 1413
+  - uid: 1559
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,0.5
       parent: 1
-  - uid: 1414
+  - uid: 1560
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10326,72 +10299,72 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 1415
+  - uid: 1561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-21.5
       parent: 1
-  - uid: 1416
+  - uid: 1562
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-18.5
       parent: 1
-  - uid: 1417
+  - uid: 1563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-18.5
       parent: 1
-  - uid: 1418
+  - uid: 1564
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 1
-  - uid: 1419
+  - uid: 1565
     components:
     - type: Transform
       pos: 12.5,-7.5
       parent: 1
-  - uid: 1420
+  - uid: 1566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-11.5
       parent: 1
-  - uid: 1421
+  - uid: 1567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-6.5
       parent: 1
-  - uid: 1422
+  - uid: 1568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-1.5
       parent: 1
-  - uid: 1423
+  - uid: 1569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,3.5
       parent: 1
-  - uid: 1424
+  - uid: 1570
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,8.5
       parent: 1
-  - uid: 1425
+  - uid: 1571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,8.5
       parent: 1
-  - uid: 1426
+  - uid: 1572
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10399,124 +10372,124 @@ entities:
       parent: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 1427
+  - uid: 1573
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 1
 - proto: PoweredlightSodium
   entities:
-  - uid: 1428
+  - uid: 1574
     components:
     - type: Transform
       pos: 7.5,21.5
       parent: 1
-  - uid: 1429
+  - uid: 1575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,37.5
       parent: 1
-  - uid: 1430
+  - uid: 1576
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,29.5
       parent: 1
-  - uid: 1431
+  - uid: 1577
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,45.5
       parent: 1
-  - uid: 1432
+  - uid: 1578
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,22.5
       parent: 1
-  - uid: 1433
+  - uid: 1579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,12.5
       parent: 1
-  - uid: 1434
+  - uid: 1580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,12.5
       parent: 1
-  - uid: 1435
+  - uid: 1581
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1
-  - uid: 1437
+  - uid: 1582
     components:
     - type: Transform
       pos: 18.5,23.5
       parent: 1
-  - uid: 1438
+  - uid: 1583
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,24.5
       parent: 1
-  - uid: 1439
+  - uid: 1584
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,17.5
       parent: 1
-  - uid: 1440
+  - uid: 1585
     components:
     - type: Transform
       pos: -1.5,40.5
       parent: 1
-  - uid: 1441
+  - uid: 1586
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 1442
+  - uid: 1587
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 1
-  - uid: 1443
+  - uid: 1588
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-13.5
       parent: 1
-  - uid: 1444
+  - uid: 1589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,23.5
       parent: 1
-  - uid: 1910
+  - uid: 1590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,28.5
       parent: 1
-  - uid: 2259
+  - uid: 1591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,27.5
       parent: 1
-  - uid: 2269
+  - uid: 1592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,29.5
       parent: 1
-  - uid: 2400
+  - uid: 1593
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10524,25 +10497,25 @@ entities:
       parent: 1
 - proto: Rack
   entities:
-  - uid: 1445
+  - uid: 1594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
-  - uid: 1446
+  - uid: 1595
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-5.5
       parent: 1
-  - uid: 1447
+  - uid: 1596
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-5.5
       parent: 1
-  - uid: 1448
+  - uid: 1597
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10550,99 +10523,99 @@ entities:
       parent: 1
 - proto: SalvageTechfabNF
   entities:
-  - uid: 1451
+  - uid: 1598
     components:
     - type: Transform
       pos: 22.5,39.5
       parent: 1
 - proto: ScrapProcessor
   entities:
-  - uid: 1452
+  - uid: 1599
     components:
     - type: Transform
       pos: 22.5,37.5
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 1453
+  - uid: 1600
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,30.5
       parent: 1
-  - uid: 1454
+  - uid: 1601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,31.5
       parent: 1
-  - uid: 1455
+  - uid: 1602
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,34.5
       parent: 1
-  - uid: 1456
+  - uid: 1603
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,35.5
       parent: 1
-  - uid: 1457
+  - uid: 1604
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,32.5
       parent: 1
-  - uid: 1458
+  - uid: 1605
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,36.5
       parent: 1
-  - uid: 1459
+  - uid: 1606
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,38.5
       parent: 1
-  - uid: 1460
+  - uid: 1607
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,39.5
       parent: 1
-  - uid: 1461
+  - uid: 1608
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,42.5
       parent: 1
-  - uid: 1462
+  - uid: 1609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,43.5
       parent: 1
-  - uid: 1463
+  - uid: 1610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,40.5
       parent: 1
-  - uid: 1464
+  - uid: 1611
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,44.5
       parent: 1
-  - uid: 1465
+  - uid: 1612
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,21.5
       parent: 1
-  - uid: 1466
+  - uid: 1613
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10650,73 +10623,73 @@ entities:
       parent: 1
 - proto: ShuttleGunKinetic
   entities:
-  - uid: 1467
+  - uid: 1614
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,29.5
       parent: 1
-  - uid: 1468
+  - uid: 1615
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,28.5
       parent: 1
-  - uid: 1469
+  - uid: 1616
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,31.5
       parent: 1
-  - uid: 1470
+  - uid: 1617
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,30.5
       parent: 1
-  - uid: 1471
+  - uid: 1618
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,33.5
       parent: 1
-  - uid: 1472
+  - uid: 1619
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,32.5
       parent: 1
-  - uid: 1473
+  - uid: 1620
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,35.5
       parent: 1
-  - uid: 1474
+  - uid: 1621
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,34.5
       parent: 1
-  - uid: 1475
+  - uid: 1622
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,37.5
       parent: 1
-  - uid: 1476
+  - uid: 1623
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,36.5
       parent: 1
-  - uid: 1477
+  - uid: 1624
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,39.5
       parent: 1
-  - uid: 1478
+  - uid: 1625
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10724,7 +10697,7 @@ entities:
       parent: 1
 - proto: SignalButtonDirectional
   entities:
-  - uid: 1479
+  - uid: 1626
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10732,19 +10705,25 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        183:
-        - Pressed: Toggle
-        191:
-        - Pressed: Toggle
-        184:
-        - Pressed: Toggle
-        12:
-        - Pressed: Toggle
+        199:
+        - - Pressed
+          - Toggle
+        207:
+        - - Pressed
+          - Toggle
+        200:
+        - - Pressed
+          - Toggle
         13:
-        - Pressed: Toggle
-        19:
-        - Pressed: Toggle
-  - uid: 1480
+        - - Pressed
+          - Toggle
+        14:
+        - - Pressed
+          - Toggle
+        20:
+        - - Pressed
+          - Toggle
+  - uid: 1627
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10752,28 +10731,35 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        185:
-        - Pressed: Toggle
-        192:
-        - Pressed: Toggle
-        186:
-        - Pressed: Toggle
-  - uid: 1481
+        201:
+        - - Pressed
+          - Toggle
+        208:
+        - - Pressed
+          - Toggle
+        202:
+        - - Pressed
+          - Toggle
+  - uid: 1628
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        176:
-        - Pressed: Toggle
-        175:
-        - Pressed: Toggle
-        181:
-        - Pressed: Toggle
-        182:
-        - Pressed: Toggle
-  - uid: 1482
+        192:
+        - - Pressed
+          - Toggle
+        191:
+        - - Pressed
+          - Toggle
+        197:
+        - - Pressed
+          - Toggle
+        198:
+        - - Pressed
+          - Toggle
+  - uid: 1629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10781,19 +10767,25 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        178:
-        - Pressed: Toggle
-        180:
-        - Pressed: Toggle
-        177:
-        - Pressed: Toggle
-        187:
-        - Pressed: Toggle
-        179:
-        - Pressed: Toggle
-        188:
-        - Pressed: Toggle
-  - uid: 1483
+        194:
+        - - Pressed
+          - Toggle
+        196:
+        - - Pressed
+          - Toggle
+        193:
+        - - Pressed
+          - Toggle
+        203:
+        - - Pressed
+          - Toggle
+        195:
+        - - Pressed
+          - Toggle
+        204:
+        - - Pressed
+          - Toggle
+  - uid: 1630
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10801,11 +10793,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        189:
-        - Pressed: Toggle
-        190:
-        - Pressed: Toggle
-  - uid: 1484
+        205:
+        - - Pressed
+          - Toggle
+        206:
+        - - Pressed
+          - Toggle
+  - uid: 1631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10813,31 +10807,43 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1468:
-        - Pressed: Toggle
-        1467:
-        - Pressed: Toggle
-        1470:
-        - Pressed: Toggle
-        1469:
-        - Pressed: Toggle
-        1472:
-        - Pressed: Toggle
-        1471:
-        - Pressed: Toggle
-        1474:
-        - Pressed: Toggle
-        1473:
-        - Pressed: Toggle
-        1476:
-        - Pressed: Toggle
-        1475:
-        - Pressed: Toggle
-        1478:
-        - Pressed: Toggle
-        1477:
-        - Pressed: Toggle
-  - uid: 1485
+        1615:
+        - - Pressed
+          - Toggle
+        1614:
+        - - Pressed
+          - Toggle
+        1617:
+        - - Pressed
+          - Toggle
+        1616:
+        - - Pressed
+          - Toggle
+        1619:
+        - - Pressed
+          - Toggle
+        1618:
+        - - Pressed
+          - Toggle
+        1621:
+        - - Pressed
+          - Toggle
+        1620:
+        - - Pressed
+          - Toggle
+        1623:
+        - - Pressed
+          - Toggle
+        1622:
+        - - Pressed
+          - Toggle
+        1625:
+        - - Pressed
+          - Toggle
+        1624:
+        - - Pressed
+          - Toggle
+  - uid: 1632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10845,11 +10851,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1466:
-        - Pressed: Toggle
-        1465:
-        - Pressed: Toggle
-  - uid: 1486
+        1613:
+        - - Pressed
+          - Toggle
+        1612:
+        - - Pressed
+          - Toggle
+  - uid: 1633
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10857,13 +10865,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1453:
-        - Pressed: Toggle
-        1454:
-        - Pressed: Toggle
-        1457:
-        - Pressed: Toggle
-  - uid: 1487
+        1600:
+        - - Pressed
+          - Toggle
+        1601:
+        - - Pressed
+          - Toggle
+        1604:
+        - - Pressed
+          - Toggle
+  - uid: 1634
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10871,13 +10882,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1455:
-        - Pressed: Toggle
-        1456:
-        - Pressed: Toggle
-        1458:
-        - Pressed: Toggle
-  - uid: 1488
+        1602:
+        - - Pressed
+          - Toggle
+        1603:
+        - - Pressed
+          - Toggle
+        1605:
+        - - Pressed
+          - Toggle
+  - uid: 1635
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10885,13 +10899,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1459:
-        - Pressed: Toggle
-        1460:
-        - Pressed: Toggle
-        1463:
-        - Pressed: Toggle
-  - uid: 1489
+        1606:
+        - - Pressed
+          - Toggle
+        1607:
+        - - Pressed
+          - Toggle
+        1610:
+        - - Pressed
+          - Toggle
+  - uid: 1636
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10899,56 +10916,59 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1461:
-        - Pressed: Toggle
-        1462:
-        - Pressed: Toggle
-        1464:
-        - Pressed: Toggle
+        1608:
+        - - Pressed
+          - Toggle
+        1609:
+        - - Pressed
+          - Toggle
+        1611:
+        - - Pressed
+          - Toggle
 - proto: SMESAdvanced
   entities:
-  - uid: 1490
+  - uid: 1637
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 1491
+  - uid: 1638
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 1492
+  - uid: 1639
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 1493
+  - uid: 1640
     components:
     - type: Transform
       pos: 20.5,45.5
       parent: 1
-  - uid: 1494
+  - uid: 1641
     components:
     - type: Transform
       pos: 5.5,23.5
       parent: 1
 - proto: StoolBar
   entities:
-  - uid: 1495
+  - uid: 1642
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-0.5
       parent: 1
-  - uid: 1496
+  - uid: 1643
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 1497
+  - uid: 1644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10956,24 +10976,24 @@ entities:
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 1498
+  - uid: 1645
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 1499
+  - uid: 1646
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 1
-  - uid: 1500
+  - uid: 1647
     components:
     - type: Transform
       pos: 21.5,45.5
       parent: 1
 - proto: SuitStorageBase
   entities:
-  - uid: 1501
+  - uid: 1648
     components:
     - type: Transform
       pos: 3.5,7.5
@@ -10996,135 +11016,135 @@ entities:
         - 0
         - 0
         - 0
-  - uid: 1502
+  - uid: 1649
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
 - proto: SuitStorageEVAPirate
   entities:
-  - uid: 1503
+  - uid: 1650
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-  - uid: 1504
+  - uid: 1651
     components:
     - type: Transform
       pos: 11.5,-1.5
       parent: 1
-  - uid: 1505
+  - uid: 1652
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 1
-  - uid: 1506
+  - uid: 1653
     components:
     - type: Transform
       pos: 12.5,-2.5
       parent: 1
-  - uid: 1507
+  - uid: 1654
     components:
     - type: Transform
       pos: 12.5,-4.5
       parent: 1
 - proto: TableCounterMetal
   entities:
-  - uid: 1508
+  - uid: 1655
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 1509
+  - uid: 1656
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 1510
+  - uid: 1657
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
 - proto: TableCounterWood
   entities:
-  - uid: 1511
+  - uid: 1658
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 1512
+  - uid: 1659
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 1513
+  - uid: 1660
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 1514
+  - uid: 1661
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 1515
+  - uid: 1662
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-  - uid: 1516
+  - uid: 1663
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 1517
+  - uid: 1664
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 1518
+  - uid: 1665
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
-  - uid: 1519
+  - uid: 1666
     components:
     - type: Transform
       pos: -1.5,25.5
       parent: 1
-  - uid: 1520
+  - uid: 1667
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,16.5
       parent: 1
-  - uid: 1521
+  - uid: 1668
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,17.5
       parent: 1
-  - uid: 1522
+  - uid: 1669
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,16.5
       parent: 1
-  - uid: 1523
+  - uid: 1670
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,18.5
       parent: 1
-  - uid: 1524
+  - uid: 1671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,18.5
       parent: 1
-  - uid: 1525
+  - uid: 1672
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11132,300 +11152,300 @@ entities:
       parent: 1
 - proto: TelecomServerFilledFreelance
   entities:
-  - uid: 1526
+  - uid: 1673
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
 - proto: ThrusterSecurity
   entities:
-  - uid: 1527
+  - uid: 1674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-6.5
       parent: 1
-  - uid: 1528
+  - uid: 1675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 1
-  - uid: 1529
+  - uid: 1676
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-9.5
       parent: 1
-  - uid: 1530
+  - uid: 1677
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-5.5
       parent: 1
-  - uid: 1531
+  - uid: 1678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-  - uid: 1532
+  - uid: 1679
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 1533
+  - uid: 1680
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 1534
+  - uid: 1681
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-3.5
       parent: 1
-  - uid: 1535
+  - uid: 1682
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 1536
+  - uid: 1683
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-5.5
       parent: 1
-  - uid: 1537
+  - uid: 1684
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-9.5
       parent: 1
-  - uid: 1538
+  - uid: 1685
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-7.5
       parent: 1
-  - uid: 1539
+  - uid: 1686
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 1540
+  - uid: 1687
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,2.5
       parent: 1
-  - uid: 1541
+  - uid: 1688
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,3.5
       parent: 1
-  - uid: 1542
+  - uid: 1689
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
-  - uid: 1543
+  - uid: 1690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 1
-  - uid: 1544
+  - uid: 1691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 1
-  - uid: 1545
+  - uid: 1692
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-0.5
       parent: 1
-  - uid: 1546
+  - uid: 1693
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 1
-  - uid: 1547
+  - uid: 1694
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 1
-  - uid: 1548
+  - uid: 1695
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-8.5
       parent: 1
-  - uid: 1549
+  - uid: 1696
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-7.5
       parent: 1
-  - uid: 1550
+  - uid: 1697
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-5.5
       parent: 1
-  - uid: 1551
+  - uid: 1698
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-3.5
       parent: 1
-  - uid: 1552
+  - uid: 1699
     components:
     - type: Transform
       pos: 26.5,-1.5
       parent: 1
-  - uid: 1553
+  - uid: 1700
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,1.5
       parent: 1
-  - uid: 1554
+  - uid: 1701
     components:
     - type: Transform
       pos: 26.5,0.5
       parent: 1
-  - uid: 1555
+  - uid: 1702
     components:
     - type: Transform
       pos: 26.5,2.5
       parent: 1
-  - uid: 1556
+  - uid: 1703
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 1
-  - uid: 1557
+  - uid: 1704
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,2.5
       parent: 1
-  - uid: 1558
+  - uid: 1705
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,3.5
       parent: 1
-  - uid: 1559
+  - uid: 1706
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,0.5
       parent: 1
-  - uid: 1560
+  - uid: 1707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,-0.5
       parent: 1
-  - uid: 1561
+  - uid: 1708
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-1.5
       parent: 1
-  - uid: 1562
+  - uid: 1709
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-2.5
       parent: 1
-  - uid: 1563
+  - uid: 1710
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-3.5
       parent: 1
-  - uid: 1564
+  - uid: 1711
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,-4.5
       parent: 1
-  - uid: 1565
+  - uid: 1712
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,-5.5
       parent: 1
-  - uid: 1566
+  - uid: 1713
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-6.5
       parent: 1
-  - uid: 1567
+  - uid: 1714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-7.5
       parent: 1
-  - uid: 1568
+  - uid: 1715
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-8.5
       parent: 1
-  - uid: 1569
+  - uid: 1716
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-16.5
       parent: 1
-  - uid: 1570
+  - uid: 1717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-17.5
       parent: 1
-  - uid: 1571
+  - uid: 1718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-18.5
       parent: 1
-  - uid: 1572
+  - uid: 1719
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-19.5
       parent: 1
-  - uid: 1573
+  - uid: 1720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-19.5
       parent: 1
-  - uid: 1574
+  - uid: 1721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-18.5
       parent: 1
-  - uid: 1575
+  - uid: 1722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-17.5
       parent: 1
-  - uid: 1576
+  - uid: 1723
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11433,3894 +11453,4287 @@ entities:
       parent: 1
 - proto: TwoWayLever
   entities:
-  - uid: 1577
+  - uid: 1724
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        929:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        928:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        930:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        927:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        926:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        931:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        932:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        925:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        934:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        924:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        933:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        922:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        935:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        923:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        921:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        920:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        936:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        944:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        937:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        946:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        898:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        938:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        942:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        919:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        918:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        943:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        888:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        945:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        905:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        941:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        940:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        886:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        939:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        894:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        950:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        951:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        912:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        952:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        885:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        913:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        949:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        887:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        948:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        909:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        947:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        896:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        895:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        893:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        906:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        903:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        915:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        891:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        904:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        910:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        911:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        907:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        914:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        889:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        897:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        908:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        900:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        902:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        892:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        890:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        916:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        917:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        901:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        881:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        883:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        882:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        884:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        879:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        955:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        975:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        880:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        974:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        954:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        973:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        957:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        956:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        972:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        971:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        958:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        989:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1010:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        976:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1009:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        953:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1008:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        990:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
+        1038:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1037:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1039:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1036:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1035:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1040:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1041:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1034:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1043:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1033:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1042:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1031:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1044:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1032:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1030:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1029:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1045:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1053:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1046:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1055:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
         1007:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        992:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1006:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        991:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1005:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1003:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1004:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1047:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1051:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1028:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1027:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1052:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
         997:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        999:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        994:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        993:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1054:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1014:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1050:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1049:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
         995:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1000:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        998:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        1002:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1048:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1003:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1059:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1060:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1021:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1061:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        994:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1022:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1058:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
         996:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1057:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1018:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1056:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1005:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1004:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1002:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1015:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1012:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1024:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1000:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1013:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1019:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1020:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1016:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1023:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        998:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1006:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1017:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1009:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1011:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
         1001:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-  - uid: 1578
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        999:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1025:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1026:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1010:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        990:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        992:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        991:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        993:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        988:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1064:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1084:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        989:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1083:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1063:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1082:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1066:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1065:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1081:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1080:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1067:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1098:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1119:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1085:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1118:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1062:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1117:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1099:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1116:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1101:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1115:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1100:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1114:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1112:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1113:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1106:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1108:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1103:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1102:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1104:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1109:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1107:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1111:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1105:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1110:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+  - uid: 1725
     components:
     - type: Transform
       pos: 20.5,23.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        988:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        968:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        987:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        986:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        969:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        970:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        959:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        960:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        961:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        977:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        962:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        978:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        963:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        979:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        964:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        980:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        965:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        981:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        983:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        982:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        967:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        985:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        984:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        966:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
+        1097:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1077:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1096:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1095:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1078:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1079:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1068:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1069:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1070:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1086:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1071:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1087:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1072:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1088:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1073:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1089:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1074:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1090:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1092:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1091:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1076:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1094:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1093:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
+        1075:
+        - - Left
+          - Forward
+        - - Right
+          - Reverse
+        - - Middle
+          - Off
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 1579
+  - uid: 1726
     components:
     - type: Transform
       pos: 13.5,-2.5
       parent: 1
-  - uid: 1580
+  - uid: 1727
     components:
     - type: Transform
       pos: 7.5,-15.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 30
+  - uid: 1728
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,49.5
       parent: 1
-  - uid: 31
+  - uid: 1729
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,48.5
       parent: 1
-  - uid: 39
+  - uid: 1730
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,49.5
       parent: 1
-  - uid: 41
+  - uid: 1731
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,47.5
       parent: 1
-  - uid: 721
+  - uid: 1732
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,28.5
       parent: 1
-  - uid: 722
+  - uid: 1733
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,28.5
       parent: 1
-  - uid: 724
+  - uid: 1734
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,24.5
       parent: 1
-  - uid: 754
+  - uid: 1735
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,25.5
       parent: 1
-  - uid: 756
+  - uid: 1736
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,27.5
       parent: 1
-  - uid: 757
+  - uid: 1737
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,25.5
       parent: 1
-  - uid: 758
+  - uid: 1738
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,26.5
       parent: 1
-  - uid: 759
+  - uid: 1739
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,27.5
       parent: 1
-  - uid: 760
+  - uid: 1740
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,27.5
       parent: 1
-  - uid: 785
+  - uid: 1741
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,23.5
       parent: 1
-  - uid: 786
+  - uid: 1742
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,26.5
       parent: 1
-  - uid: 1193
+  - uid: 1743
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,51.5
       parent: 1
-  - uid: 1194
+  - uid: 1744
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,52.5
       parent: 1
-  - uid: 1298
+  - uid: 1745
     components:
     - type: Transform
       pos: -1.5,43.5
       parent: 1
-  - uid: 1300
+  - uid: 1746
     components:
     - type: Transform
       pos: 0.5,43.5
       parent: 1
-  - uid: 1302
+  - uid: 1747
     components:
     - type: Transform
       pos: -1.5,44.5
       parent: 1
-  - uid: 1303
+  - uid: 1748
     components:
     - type: Transform
       pos: 0.5,45.5
       parent: 1
-  - uid: 1305
+  - uid: 1749
     components:
     - type: Transform
       pos: 0.5,44.5
       parent: 1
-  - uid: 1309
+  - uid: 1750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,47.5
       parent: 1
-  - uid: 1310
+  - uid: 1751
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,48.5
       parent: 1
-  - uid: 1311
+  - uid: 1752
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,48.5
       parent: 1
-  - uid: 1312
+  - uid: 1753
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,47.5
       parent: 1
-  - uid: 1313
+  - uid: 1754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,48.5
       parent: 1
-  - uid: 1314
+  - uid: 1755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,47.5
       parent: 1
-  - uid: 1343
+  - uid: 1756
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,15.5
       parent: 1
-  - uid: 1346
+  - uid: 1757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,15.5
       parent: 1
-  - uid: 1581
+  - uid: 1758
     components:
     - type: Transform
       pos: 14.5,24.5
       parent: 1
-  - uid: 1582
-    components:
-    - type: Transform
-      pos: 15.5,25.5
-      parent: 1
-  - uid: 1583
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,27.5
-      parent: 1
-  - uid: 1584
-    components:
-    - type: Transform
-      pos: 15.5,26.5
-      parent: 1
-  - uid: 1585
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,23.5
-      parent: 1
-  - uid: 1586
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,23.5
-      parent: 1
-  - uid: 1587
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,4.5
-      parent: 1
-  - uid: 1588
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-11.5
-      parent: 1
-  - uid: 1589
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-10.5
-      parent: 1
-  - uid: 1590
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-9.5
-      parent: 1
-  - uid: 1591
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-11.5
-      parent: 1
-  - uid: 1592
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-10.5
-      parent: 1
-  - uid: 1593
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-9.5
-      parent: 1
-  - uid: 1594
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,4.5
-      parent: 1
-  - uid: 1595
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,5.5
-      parent: 1
-  - uid: 1596
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,6.5
-      parent: 1
-  - uid: 1597
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,2.5
-      parent: 1
-  - uid: 1598
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,3.5
-      parent: 1
-  - uid: 1599
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,4.5
-      parent: 1
-  - uid: 1600
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,6.5
-      parent: 1
-  - uid: 1601
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,5.5
-      parent: 1
-  - uid: 1602
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,0.5
-      parent: 1
-  - uid: 1603
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-0.5
-      parent: 1
-  - uid: 1604
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-2.5
-      parent: 1
-  - uid: 1605
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-2.5
-      parent: 1
-  - uid: 1606
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,1.5
-      parent: 1
-  - uid: 1607
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 1
-  - uid: 1608
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-1.5
-      parent: 1
-  - uid: 1609
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,0.5
-      parent: 1
-  - uid: 1610
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-0.5
-      parent: 1
-  - uid: 1611
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
-  - uid: 1612
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-2.5
-      parent: 1
-  - uid: 1613
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-4.5
-      parent: 1
-  - uid: 1614
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-3.5
-      parent: 1
-  - uid: 1615
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-5.5
-      parent: 1
-  - uid: 1616
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 1617
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-3.5
-      parent: 1
-  - uid: 1618
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-4.5
-      parent: 1
-  - uid: 1619
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-5.5
-      parent: 1
-  - uid: 1620
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-6.5
-      parent: 1
-  - uid: 1621
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-8.5
-      parent: 1
-  - uid: 1622
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-7.5
-      parent: 1
-  - uid: 1623
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-4.5
-      parent: 1
-  - uid: 1624
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-5.5
-      parent: 1
-  - uid: 1625
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
-      parent: 1
-  - uid: 1626
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 1627
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-2.5
-      parent: 1
-  - uid: 1628
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 1629
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 1
-  - uid: 1630
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,6.5
-      parent: 1
-  - uid: 1631
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,5.5
-      parent: 1
-  - uid: 1632
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,4.5
-      parent: 1
-  - uid: 1633
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,3.5
-      parent: 1
-  - uid: 1634
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,2.5
-      parent: 1
-  - uid: 1635
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,1.5
-      parent: 1
-  - uid: 1636
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,0.5
-      parent: 1
-  - uid: 1637
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-0.5
-      parent: 1
-  - uid: 1638
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-1.5
-      parent: 1
-  - uid: 1639
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-2.5
-      parent: 1
-  - uid: 1640
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-3.5
-      parent: 1
-  - uid: 1641
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-4.5
-      parent: 1
-  - uid: 1642
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-5.5
-      parent: 1
-  - uid: 1643
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-6.5
-      parent: 1
-  - uid: 1644
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-7.5
-      parent: 1
-  - uid: 1645
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-8.5
-      parent: 1
-  - uid: 1646
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-9.5
-      parent: 1
-  - uid: 1647
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-10.5
-      parent: 1
-  - uid: 1648
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-11.5
-      parent: 1
-  - uid: 1649
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,-11.5
-      parent: 1
-  - uid: 1650
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,-10.5
-      parent: 1
-  - uid: 1651
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,-9.5
-      parent: 1
-  - uid: 1652
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-2.5
-      parent: 1
-  - uid: 1653
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-5.5
-      parent: 1
-  - uid: 1654
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-4.5
-      parent: 1
-  - uid: 1655
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-3.5
-      parent: 1
-  - uid: 1656
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-2.5
-      parent: 1
-  - uid: 1657
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-1.5
-      parent: 1
-  - uid: 1658
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-0.5
-      parent: 1
-  - uid: 1659
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,0.5
-      parent: 1
-  - uid: 1660
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-2.5
-      parent: 1
-  - uid: 1661
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-2.5
-      parent: 1
-  - uid: 1662
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,-5.5
-      parent: 1
-  - uid: 1663
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,-4.5
-      parent: 1
-  - uid: 1664
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,0.5
-      parent: 1
-  - uid: 1665
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,-0.5
-      parent: 1
-  - uid: 1666
-    components:
-    - type: Transform
-      pos: 22.5,-7.5
-      parent: 1
-  - uid: 1667
-    components:
-    - type: Transform
-      pos: 21.5,-7.5
-      parent: 1
-  - uid: 1668
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,5.5
-      parent: 1
-  - uid: 1669
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,6.5
-      parent: 1
-  - uid: 1670
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-8.5
-      parent: 1
-  - uid: 1671
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-9.5
-      parent: 1
-  - uid: 1672
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-11.5
-      parent: 1
-  - uid: 1673
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-10.5
-      parent: 1
-  - uid: 1674
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-11.5
-      parent: 1
-  - uid: 1675
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-12.5
-      parent: 1
-  - uid: 1676
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-13.5
-      parent: 1
-  - uid: 1677
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-15.5
-      parent: 1
-  - uid: 1678
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-14.5
-      parent: 1
-  - uid: 1679
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-16.5
-      parent: 1
-  - uid: 1680
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-16.5
-      parent: 1
-  - uid: 1681
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-17.5
-      parent: 1
-  - uid: 1682
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-18.5
-      parent: 1
-  - uid: 1683
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-19.5
-      parent: 1
-  - uid: 1684
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-20.5
-      parent: 1
-  - uid: 1685
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-21.5
-      parent: 1
-  - uid: 1686
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-15.5
-      parent: 1
-  - uid: 1687
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-14.5
-      parent: 1
-  - uid: 1688
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-13.5
-      parent: 1
-  - uid: 1689
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-12.5
-      parent: 1
-  - uid: 1690
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-11.5
-      parent: 1
-  - uid: 1691
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-10.5
-      parent: 1
-  - uid: 1692
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-9.5
-      parent: 1
-  - uid: 1693
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-7.5
-      parent: 1
-  - uid: 1694
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-8.5
-      parent: 1
-  - uid: 1695
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-7.5
-      parent: 1
-  - uid: 1696
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-8.5
-      parent: 1
-  - uid: 1697
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-9.5
-      parent: 1
-  - uid: 1698
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-11.5
-      parent: 1
-  - uid: 1699
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-10.5
-      parent: 1
-  - uid: 1700
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-11.5
-      parent: 1
-  - uid: 1701
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-10.5
-      parent: 1
-  - uid: 1702
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-9.5
-      parent: 1
-  - uid: 1703
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-8.5
-      parent: 1
-  - uid: 1704
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-11.5
-      parent: 1
-  - uid: 1705
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-12.5
-      parent: 1
-  - uid: 1706
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-13.5
-      parent: 1
-  - uid: 1707
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-14.5
-      parent: 1
-  - uid: 1708
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-15.5
-      parent: 1
-  - uid: 1709
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-16.5
-      parent: 1
-  - uid: 1710
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-12.5
-      parent: 1
-  - uid: 1711
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-13.5
-      parent: 1
-  - uid: 1712
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-14.5
-      parent: 1
-  - uid: 1713
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-15.5
-      parent: 1
-  - uid: 1714
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-16.5
-      parent: 1
-  - uid: 1715
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-17.5
-      parent: 1
-  - uid: 1716
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-18.5
-      parent: 1
-  - uid: 1717
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-20.5
-      parent: 1
-  - uid: 1718
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-19.5
-      parent: 1
-  - uid: 1719
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-21.5
-      parent: 1
-  - uid: 1720
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,4.5
-      parent: 1
-  - uid: 1721
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,5.5
-      parent: 1
-  - uid: 1722
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,4.5
-      parent: 1
-  - uid: 1723
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,5.5
-      parent: 1
-  - uid: 1724
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,5.5
-      parent: 1
-  - uid: 1725
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 1726
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,5.5
-      parent: 1
-  - uid: 1727
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 1728
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,5.5
-      parent: 1
-  - uid: 1729
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,4.5
-      parent: 1
-  - uid: 1730
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,5.5
-      parent: 1
-  - uid: 1731
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,4.5
-      parent: 1
-  - uid: 1732
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 1733
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,2.5
-      parent: 1
-  - uid: 1734
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,1.5
-      parent: 1
-  - uid: 1735
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 1736
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,0.5
-      parent: 1
-  - uid: 1737
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 1738
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 1739
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-3.5
-      parent: 1
-  - uid: 1740
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 1741
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 1742
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-6.5
-      parent: 1
-  - uid: 1743
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 1744
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 1745
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,1.5
-      parent: 1
-  - uid: 1746
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 1747
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 1748
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 1749
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 1750
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-3.5
-      parent: 1
-  - uid: 1751
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 1752
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-5.5
-      parent: 1
-  - uid: 1753
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-6.5
-      parent: 1
-  - uid: 1754
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-6.5
-      parent: 1
-  - uid: 1755
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-5.5
-      parent: 1
-  - uid: 1756
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-4.5
-      parent: 1
-  - uid: 1757
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-3.5
-      parent: 1
-  - uid: 1758
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-2.5
-      parent: 1
   - uid: 1759
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-1.5
+      pos: 15.5,25.5
       parent: 1
   - uid: 1760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 20.5,-0.5
+      pos: 4.5,27.5
       parent: 1
   - uid: 1761
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,0.5
+      pos: 15.5,26.5
       parent: 1
   - uid: 1762
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 20.5,1.5
+      pos: 13.5,23.5
       parent: 1
   - uid: 1763
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 20.5,2.5
+      pos: 7.5,23.5
       parent: 1
   - uid: 1764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 20.5,3.5
+      pos: 27.5,4.5
       parent: 1
   - uid: 1765
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-11.5
       parent: 1
   - uid: 1766
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-10.5
       parent: 1
   - uid: 1767
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-6.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-9.5
       parent: 1
   - uid: 1768
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-5.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-11.5
       parent: 1
   - uid: 1769
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-4.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-10.5
       parent: 1
   - uid: 1770
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-9.5
       parent: 1
   - uid: 1771
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,4.5
       parent: 1
   - uid: 1772
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,5.5
       parent: 1
   - uid: 1773
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,6.5
       parent: 1
   - uid: 1774
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
       parent: 1
   - uid: 1775
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
       parent: 1
   - uid: 1776
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,2.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
       parent: 1
   - uid: 1777
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,3.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
       parent: 1
   - uid: 1778
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
       parent: 1
   - uid: 1779
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
       parent: 1
   - uid: 1780
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
       parent: 1
   - uid: 1781
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
       parent: 1
   - uid: 1782
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
       parent: 1
   - uid: 1783
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
       parent: 1
   - uid: 1784
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
       parent: 1
   - uid: 1785
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
       parent: 1
   - uid: 1786
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,10.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
       parent: 1
   - uid: 1787
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,11.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
       parent: 1
   - uid: 1788
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
       parent: 1
   - uid: 1789
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
       parent: 1
   - uid: 1790
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-4.5
       parent: 1
   - uid: 1791
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-3.5
       parent: 1
   - uid: 1792
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,10.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
       parent: 1
   - uid: 1793
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,11.5
+      pos: -3.5,0.5
       parent: 1
   - uid: 1794
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
       parent: 1
   - uid: 1795
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
       parent: 1
   - uid: 1796
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
       parent: 1
   - uid: 1797
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-6.5
       parent: 1
   - uid: 1798
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,10.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-8.5
       parent: 1
   - uid: 1799
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,11.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
       parent: 1
   - uid: 1800
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-4.5
       parent: 1
   - uid: 1801
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-5.5
       parent: 1
   - uid: 1802
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,8.5
+      pos: -1.5,-7.5
       parent: 1
   - uid: 1803
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
       parent: 1
   - uid: 1804
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,10.5
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
       parent: 1
   - uid: 1805
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,11.5
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
       parent: 1
   - uid: 1806
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,16.5
+      pos: -0.5,-7.5
       parent: 1
   - uid: 1807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,15.5
+      pos: 25.5,6.5
       parent: 1
   - uid: 1808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,14.5
+      pos: 25.5,5.5
       parent: 1
   - uid: 1809
     components:
     - type: Transform
-      pos: 6.5,25.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,4.5
       parent: 1
   - uid: 1810
     components:
     - type: Transform
-      pos: 6.5,24.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,3.5
       parent: 1
   - uid: 1811
     components:
     - type: Transform
-      pos: 5.5,25.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,2.5
       parent: 1
   - uid: 1812
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-10.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,1.5
       parent: 1
   - uid: 1813
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-8.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,0.5
       parent: 1
   - uid: 1814
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-10.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,-0.5
       parent: 1
   - uid: 1815
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-9.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,-1.5
       parent: 1
   - uid: 1816
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-7.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,-2.5
       parent: 1
   - uid: 1817
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-7.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,-3.5
       parent: 1
   - uid: 1818
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-8.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,-4.5
       parent: 1
   - uid: 1819
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-9.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,-5.5
       parent: 1
   - uid: 1820
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-21.5
+      rot: 3.141592653589793 rad
+      pos: 25.5,-6.5
       parent: 1
   - uid: 1821
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,-14.5
+      pos: 25.5,-7.5
       parent: 1
   - uid: 1822
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,-15.5
+      pos: 25.5,-8.5
       parent: 1
   - uid: 1823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 16.5,-14.5
+      pos: 25.5,-9.5
       parent: 1
   - uid: 1824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 16.5,-15.5
+      pos: 25.5,-10.5
       parent: 1
   - uid: 1825
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 16.5,-16.5
+      pos: 25.5,-11.5
       parent: 1
   - uid: 1826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,-17.5
+      pos: 27.5,-11.5
       parent: 1
   - uid: 1827
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,-16.5
+      pos: 27.5,-10.5
       parent: 1
   - uid: 1828
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,-18.5
+      pos: 27.5,-9.5
       parent: 1
   - uid: 1829
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,-17.5
+      pos: 23.5,-2.5
       parent: 1
   - uid: 1830
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-18.5
+      pos: 24.5,-5.5
       parent: 1
   - uid: 1831
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-17.5
+      pos: 24.5,-4.5
       parent: 1
   - uid: 1832
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-19.5
+      pos: 24.5,-3.5
       parent: 1
   - uid: 1833
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-20.5
+      pos: 24.5,-2.5
       parent: 1
   - uid: 1834
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-21.5
+      pos: 24.5,-1.5
       parent: 1
   - uid: 1835
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-22.5
+      pos: 24.5,-0.5
       parent: 1
   - uid: 1836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,-22.5
+      pos: 24.5,0.5
       parent: 1
   - uid: 1837
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,-21.5
+      pos: 22.5,-2.5
       parent: 1
   - uid: 1838
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,-20.5
+      pos: 21.5,-2.5
       parent: 1
   - uid: 1839
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,-19.5
+      pos: 27.5,-5.5
       parent: 1
   - uid: 1840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,-18.5
+      pos: 27.5,-4.5
       parent: 1
   - uid: 1841
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,-17.5
+      pos: 27.5,0.5
       parent: 1
   - uid: 1842
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-18.5
+      pos: 27.5,-0.5
       parent: 1
   - uid: 1843
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-17.5
+      pos: 22.5,-7.5
       parent: 1
   - uid: 1844
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-16.5
+      pos: 21.5,-7.5
       parent: 1
   - uid: 1845
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-17.5
+      pos: 27.5,5.5
       parent: 1
   - uid: 1846
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-16.5
+      pos: 27.5,6.5
       parent: 1
   - uid: 1847
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-15.5
+      pos: 21.5,-8.5
       parent: 1
   - uid: 1848
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-14.5
+      pos: 21.5,-9.5
       parent: 1
   - uid: 1849
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-15.5
+      pos: 21.5,-11.5
       parent: 1
   - uid: 1850
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-14.5
+      pos: 21.5,-10.5
       parent: 1
   - uid: 1851
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,-11.5
       parent: 1
   - uid: 1852
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,-12.5
       parent: 1
   - uid: 1853
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-14.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,-13.5
       parent: 1
   - uid: 1854
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-14.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,-15.5
       parent: 1
   - uid: 1855
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-15.5
+      pos: 20.5,-14.5
       parent: 1
   - uid: 1856
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-16.5
+      pos: 20.5,-16.5
       parent: 1
   - uid: 1857
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,-16.5
+      pos: 19.5,-16.5
       parent: 1
   - uid: 1858
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,-15.5
+      pos: 19.5,-17.5
       parent: 1
   - uid: 1859
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,-16.5
+      pos: 19.5,-18.5
       parent: 1
   - uid: 1860
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,-16.5
+      pos: 19.5,-19.5
       parent: 1
   - uid: 1861
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-14.5
+      pos: 19.5,-20.5
       parent: 1
   - uid: 1862
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-15.5
+      pos: 19.5,-21.5
       parent: 1
   - uid: 1863
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,-15.5
+      pos: 19.5,-15.5
       parent: 1
   - uid: 1864
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,-14.5
+      pos: 19.5,-14.5
       parent: 1
   - uid: 1865
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-20.5
+      rot: 3.141592653589793 rad
+      pos: 19.5,-13.5
       parent: 1
   - uid: 1866
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-19.5
+      rot: 3.141592653589793 rad
+      pos: 19.5,-12.5
       parent: 1
   - uid: 1867
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-19.5
+      rot: 3.141592653589793 rad
+      pos: 19.5,-11.5
       parent: 1
   - uid: 1868
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-20.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,-10.5
       parent: 1
   - uid: 1869
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-21.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,-9.5
       parent: 1
   - uid: 1870
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,16.5
+      pos: 20.5,-7.5
       parent: 1
   - uid: 1871
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,17.5
+      pos: 20.5,-8.5
       parent: 1
   - uid: 1872
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,17.5
+      pos: 0.5,-7.5
       parent: 1
   - uid: 1873
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,19.5
+      pos: 0.5,-8.5
       parent: 1
   - uid: 1874
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,16.5
+      pos: 0.5,-9.5
       parent: 1
   - uid: 1875
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,17.5
+      pos: 0.5,-11.5
       parent: 1
   - uid: 1876
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,18.5
+      pos: 0.5,-10.5
       parent: 1
   - uid: 1877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,16.5
+      pos: -0.5,-11.5
       parent: 1
   - uid: 1878
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,12.5
+      pos: -0.5,-10.5
       parent: 1
   - uid: 1879
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,13.5
+      pos: -0.5,-9.5
       parent: 1
   - uid: 1880
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,14.5
+      pos: -0.5,-8.5
       parent: 1
   - uid: 1881
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,15.5
+      pos: 1.5,-11.5
       parent: 1
   - uid: 1882
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,14.5
+      pos: 0.5,-12.5
       parent: 1
   - uid: 1883
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,15.5
+      pos: 0.5,-13.5
       parent: 1
   - uid: 1884
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,19.5
+      pos: 0.5,-14.5
       parent: 1
   - uid: 1885
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,18.5
+      pos: 0.5,-15.5
       parent: 1
   - uid: 1886
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,13.5
+      pos: 0.5,-16.5
       parent: 1
   - uid: 1887
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,12.5
+      pos: 1.5,-12.5
       parent: 1
   - uid: 1888
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,13.5
+      pos: 1.5,-13.5
       parent: 1
   - uid: 1889
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,12.5
+      pos: 1.5,-14.5
       parent: 1
   - uid: 1890
     components:
     - type: Transform
-      pos: 5.5,26.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,-15.5
       parent: 1
   - uid: 1891
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,22.5
+      pos: 1.5,-16.5
       parent: 1
   - uid: 1892
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,18.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,-17.5
       parent: 1
   - uid: 1893
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,18.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,-18.5
       parent: 1
   - uid: 1894
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,17.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,-20.5
       parent: 1
   - uid: 1895
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,19.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,-19.5
       parent: 1
   - uid: 1896
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,-21.5
       parent: 1
   - uid: 1897
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,16.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,4.5
       parent: 1
   - uid: 1898
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,15.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,5.5
       parent: 1
   - uid: 1899
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,16.5
+      rot: 3.141592653589793 rad
+      pos: 14.5,4.5
       parent: 1
   - uid: 1900
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,17.5
+      rot: 3.141592653589793 rad
+      pos: 14.5,5.5
       parent: 1
   - uid: 1901
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,19.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,5.5
       parent: 1
   - uid: 1902
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,17.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
       parent: 1
   - uid: 1903
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,12.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,5.5
       parent: 1
   - uid: 1904
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,13.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
       parent: 1
   - uid: 1905
     components:
     - type: Transform
-      pos: 26.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 1906
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 1907
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
       parent: 1
   - uid: 1908
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,26.5
+      pos: 3.5,4.5
       parent: 1
   - uid: 1909
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 1910
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 1911
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 1912
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 1913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 1914
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 1915
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 1916
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 1917
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 1918
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 1919
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 1920
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 1921
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 1922
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 1923
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 1924
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 1925
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 1926
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 1927
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 1928
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 1929
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 1930
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 1931
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-6.5
+      parent: 1
+  - uid: 1932
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-5.5
+      parent: 1
+  - uid: 1933
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-4.5
+      parent: 1
+  - uid: 1934
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-3.5
+      parent: 1
+  - uid: 1935
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-2.5
+      parent: 1
+  - uid: 1936
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-1.5
+      parent: 1
+  - uid: 1937
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-0.5
+      parent: 1
+  - uid: 1938
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,0.5
+      parent: 1
+  - uid: 1939
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,1.5
+      parent: 1
+  - uid: 1940
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,2.5
+      parent: 1
+  - uid: 1941
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,3.5
+      parent: 1
+  - uid: 1942
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,4.5
+      parent: 1
+  - uid: 1943
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,5.5
+      parent: 1
+  - uid: 1944
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-6.5
+      parent: 1
+  - uid: 1945
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-5.5
+      parent: 1
+  - uid: 1946
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-4.5
+      parent: 1
+  - uid: 1947
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-3.5
+      parent: 1
+  - uid: 1948
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-2.5
+      parent: 1
+  - uid: 1949
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-1.5
+      parent: 1
+  - uid: 1950
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-0.5
+      parent: 1
+  - uid: 1951
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,0.5
+      parent: 1
+  - uid: 1952
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,1.5
+      parent: 1
+  - uid: 1953
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,2.5
+      parent: 1
+  - uid: 1954
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,3.5
+      parent: 1
+  - uid: 1955
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,4.5
+      parent: 1
+  - uid: 1956
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,5.5
+      parent: 1
+  - uid: 1957
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,5.5
+      parent: 1
+  - uid: 1958
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,4.5
+      parent: 1
+  - uid: 1959
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 1960
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 1961
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 1962
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 1963
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 1964
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 1965
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 1966
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 1967
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 1968
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 1969
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 1970
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 1971
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,6.5
+      parent: 1
+  - uid: 1972
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,7.5
+      parent: 1
+  - uid: 1973
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,8.5
+      parent: 1
+  - uid: 1974
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,9.5
+      parent: 1
+  - uid: 1975
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,10.5
+      parent: 1
+  - uid: 1976
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,11.5
+      parent: 1
+  - uid: 1977
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,6.5
+      parent: 1
+  - uid: 1978
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,7.5
+      parent: 1
+  - uid: 1979
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,8.5
+      parent: 1
+  - uid: 1980
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,9.5
+      parent: 1
+  - uid: 1981
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,10.5
+      parent: 1
+  - uid: 1982
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,11.5
+      parent: 1
+  - uid: 1983
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,16.5
+      parent: 1
+  - uid: 1984
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 1985
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 1986
+    components:
+    - type: Transform
+      pos: 6.5,25.5
+      parent: 1
+  - uid: 1987
+    components:
+    - type: Transform
+      pos: 6.5,24.5
+      parent: 1
+  - uid: 1988
+    components:
+    - type: Transform
+      pos: 5.5,25.5
+      parent: 1
+  - uid: 1989
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 1990
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-8.5
+      parent: 1
+  - uid: 1991
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-10.5
+      parent: 1
+  - uid: 1992
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-9.5
+      parent: 1
+  - uid: 1993
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-7.5
+      parent: 1
+  - uid: 1994
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 1995
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 1996
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 1997
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-21.5
+      parent: 1
+  - uid: 1998
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-14.5
+      parent: 1
+  - uid: 1999
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-15.5
+      parent: 1
+  - uid: 2000
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-14.5
+      parent: 1
+  - uid: 2001
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-15.5
+      parent: 1
+  - uid: 2002
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-16.5
+      parent: 1
+  - uid: 2003
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-17.5
+      parent: 1
+  - uid: 2004
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-16.5
+      parent: 1
+  - uid: 2005
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-18.5
+      parent: 1
+  - uid: 2006
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-17.5
+      parent: 1
+  - uid: 2007
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-18.5
+      parent: 1
+  - uid: 2008
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-17.5
+      parent: 1
+  - uid: 2009
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-19.5
+      parent: 1
+  - uid: 2010
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-20.5
+      parent: 1
+  - uid: 2011
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-21.5
+      parent: 1
+  - uid: 2012
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-22.5
+      parent: 1
+  - uid: 2013
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-22.5
+      parent: 1
+  - uid: 2014
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-21.5
+      parent: 1
+  - uid: 2015
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-20.5
+      parent: 1
+  - uid: 2016
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-19.5
+      parent: 1
+  - uid: 2017
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-18.5
+      parent: 1
+  - uid: 2018
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-17.5
+      parent: 1
+  - uid: 2019
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-18.5
+      parent: 1
+  - uid: 2020
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-17.5
+      parent: 1
+  - uid: 2021
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-16.5
+      parent: 1
+  - uid: 2022
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-17.5
+      parent: 1
+  - uid: 2023
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-16.5
+      parent: 1
+  - uid: 2024
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-15.5
+      parent: 1
+  - uid: 2025
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-14.5
+      parent: 1
+  - uid: 2026
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-15.5
+      parent: 1
+  - uid: 2027
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 2028
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-15.5
+      parent: 1
+  - uid: 2029
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-15.5
+      parent: 1
+  - uid: 2030
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 2031
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-14.5
+      parent: 1
+  - uid: 2032
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-15.5
+      parent: 1
+  - uid: 2033
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-16.5
+      parent: 1
+  - uid: 2034
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-16.5
+      parent: 1
+  - uid: 2035
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-15.5
+      parent: 1
+  - uid: 2036
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-16.5
+      parent: 1
+  - uid: 2037
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-16.5
+      parent: 1
+  - uid: 2038
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-14.5
+      parent: 1
+  - uid: 2039
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-15.5
+      parent: 1
+  - uid: 2040
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-15.5
+      parent: 1
+  - uid: 2041
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-14.5
+      parent: 1
+  - uid: 2042
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-20.5
+      parent: 1
+  - uid: 2043
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-19.5
+      parent: 1
+  - uid: 2044
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-19.5
+      parent: 1
+  - uid: 2045
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-20.5
+      parent: 1
+  - uid: 2046
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-21.5
+      parent: 1
+  - uid: 2047
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 2048
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 2049
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 2050
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,19.5
+      parent: 1
+  - uid: 2051
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 2052
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 2053
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,18.5
+      parent: 1
+  - uid: 2054
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 2055
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,12.5
+      parent: 1
+  - uid: 2056
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,13.5
+      parent: 1
+  - uid: 2057
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,14.5
+      parent: 1
+  - uid: 2058
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,15.5
+      parent: 1
+  - uid: 2059
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 2060
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 2061
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 2062
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 2063
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 2064
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 2065
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 2066
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 2067
+    components:
+    - type: Transform
+      pos: 5.5,26.5
+      parent: 1
+  - uid: 2068
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,22.5
+      parent: 1
+  - uid: 2069
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,18.5
+      parent: 1
+  - uid: 2070
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,18.5
+      parent: 1
+  - uid: 2071
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,17.5
+      parent: 1
+  - uid: 2072
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,19.5
+      parent: 1
+  - uid: 2073
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,14.5
+      parent: 1
+  - uid: 2074
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,16.5
+      parent: 1
+  - uid: 2075
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,15.5
+      parent: 1
+  - uid: 2076
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,16.5
+      parent: 1
+  - uid: 2077
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,17.5
+      parent: 1
+  - uid: 2078
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,19.5
+      parent: 1
+  - uid: 2079
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,17.5
+      parent: 1
+  - uid: 2080
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,12.5
+      parent: 1
+  - uid: 2081
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,13.5
+      parent: 1
+  - uid: 2082
+    components:
+    - type: Transform
+      pos: 26.5,-2.5
+      parent: 1
+  - uid: 2083
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,26.5
+      parent: 1
+  - uid: 2084
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,26.5
       parent: 1
-  - uid: 1983
+  - uid: 2085
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,11.5
       parent: 1
-  - uid: 1984
+  - uid: 2086
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,10.5
       parent: 1
-  - uid: 1985
+  - uid: 2087
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,11.5
       parent: 1
-  - uid: 1986
+  - uid: 2088
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-17.5
       parent: 1
-  - uid: 1987
+  - uid: 2089
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 1988
+  - uid: 2090
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 1989
+  - uid: 2091
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 1990
+  - uid: 2092
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 1991
+  - uid: 2093
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 1992
+  - uid: 2094
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 1993
+  - uid: 2095
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 1994
+  - uid: 2096
     components:
     - type: Transform
       pos: 22.5,-8.5
       parent: 1
-  - uid: 1995
+  - uid: 2097
     components:
     - type: Transform
       pos: 22.5,-9.5
       parent: 1
-  - uid: 1996
+  - uid: 2098
     components:
     - type: Transform
       pos: 22.5,-10.5
       parent: 1
-  - uid: 1997
+  - uid: 2099
     components:
     - type: Transform
       pos: 21.5,-12.5
       parent: 1
-  - uid: 1998
+  - uid: 2100
     components:
     - type: Transform
       pos: 21.5,-13.5
       parent: 1
-  - uid: 1999
+  - uid: 2101
     components:
     - type: Transform
       pos: 21.5,-14.5
       parent: 1
-  - uid: 2000
+  - uid: 2102
     components:
     - type: Transform
       pos: 21.5,-15.5
       parent: 1
-  - uid: 2001
+  - uid: 2103
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,-17.5
       parent: 1
-  - uid: 2002
+  - uid: 2104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,6.5
       parent: 1
-  - uid: 2003
+  - uid: 2105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
-  - uid: 2004
+  - uid: 2106
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,8.5
       parent: 1
-  - uid: 2005
+  - uid: 2107
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,9.5
       parent: 1
-  - uid: 2006
+  - uid: 2108
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,10.5
       parent: 1
-  - uid: 2007
+  - uid: 2109
     components:
     - type: Transform
       pos: 20.5,6.5
       parent: 1
-  - uid: 2008
+  - uid: 2110
     components:
     - type: Transform
       pos: 20.5,7.5
       parent: 1
-  - uid: 2009
+  - uid: 2111
     components:
     - type: Transform
       pos: 20.5,8.5
       parent: 1
-  - uid: 2010
+  - uid: 2112
     components:
     - type: Transform
       pos: 20.5,9.5
       parent: 1
-  - uid: 2011
+  - uid: 2113
     components:
     - type: Transform
       pos: 20.5,10.5
       parent: 1
-  - uid: 2012
+  - uid: 2114
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,6.5
       parent: 1
-  - uid: 2013
+  - uid: 2115
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 2014
+  - uid: 2116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,6.5
       parent: 1
-  - uid: 2028
+  - uid: 2117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,7.5
       parent: 1
-  - uid: 2029
+  - uid: 2118
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,9.5
       parent: 1
-  - uid: 2030
+  - uid: 2119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,8.5
       parent: 1
-  - uid: 2031
+  - uid: 2120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,7.5
       parent: 1
-  - uid: 2032
+  - uid: 2121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,8.5
       parent: 1
-  - uid: 2033
+  - uid: 2122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,9.5
       parent: 1
-  - uid: 2065
+  - uid: 2123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,10.5
       parent: 1
-  - uid: 2066
+  - uid: 2124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,11.5
       parent: 1
-  - uid: 2067
+  - uid: 2125
     components:
     - type: Transform
       pos: 23.5,19.5
       parent: 1
-  - uid: 2068
+  - uid: 2126
     components:
     - type: Transform
       pos: 23.5,20.5
       parent: 1
-  - uid: 2069
+  - uid: 2127
     components:
     - type: Transform
       pos: 23.5,21.5
       parent: 1
-  - uid: 2070
+  - uid: 2128
     components:
     - type: Transform
       pos: 23.5,22.5
       parent: 1
-  - uid: 2071
+  - uid: 2129
     components:
     - type: Transform
       pos: 23.5,23.5
       parent: 1
-  - uid: 2072
+  - uid: 2130
     components:
     - type: Transform
       pos: 23.5,24.5
       parent: 1
-  - uid: 2073
+  - uid: 2131
     components:
     - type: Transform
       pos: 23.5,25.5
       parent: 1
-  - uid: 2074
+  - uid: 2132
     components:
     - type: Transform
       pos: 23.5,26.5
       parent: 1
-  - uid: 2075
+  - uid: 2133
     components:
     - type: Transform
       pos: 23.5,27.5
       parent: 1
-  - uid: 2076
+  - uid: 2134
     components:
     - type: Transform
       pos: 23.5,28.5
       parent: 1
-  - uid: 2077
+  - uid: 2135
     components:
     - type: Transform
       pos: 23.5,29.5
       parent: 1
-  - uid: 2078
+  - uid: 2136
     components:
     - type: Transform
       pos: 23.5,30.5
       parent: 1
-  - uid: 2079
+  - uid: 2137
     components:
     - type: Transform
       pos: 23.5,32.5
       parent: 1
-  - uid: 2080
+  - uid: 2138
     components:
     - type: Transform
       pos: 23.5,33.5
       parent: 1
-  - uid: 2081
+  - uid: 2139
     components:
     - type: Transform
       pos: 23.5,34.5
       parent: 1
-  - uid: 2082
+  - uid: 2140
     components:
     - type: Transform
       pos: 23.5,36.5
       parent: 1
-  - uid: 2083
+  - uid: 2141
     components:
     - type: Transform
       pos: 23.5,37.5
       parent: 1
-  - uid: 2084
+  - uid: 2142
     components:
     - type: Transform
       pos: 23.5,38.5
       parent: 1
-  - uid: 2085
+  - uid: 2143
     components:
     - type: Transform
       pos: 23.5,39.5
       parent: 1
-  - uid: 2086
+  - uid: 2144
     components:
     - type: Transform
       pos: 23.5,40.5
       parent: 1
-  - uid: 2087
+  - uid: 2145
     components:
     - type: Transform
       pos: 23.5,41.5
       parent: 1
-  - uid: 2088
+  - uid: 2146
     components:
     - type: Transform
       pos: 23.5,44.5
       parent: 1
-  - uid: 2089
+  - uid: 2147
     components:
     - type: Transform
       pos: 22.5,44.5
       parent: 1
-  - uid: 2090
+  - uid: 2148
     components:
     - type: Transform
       pos: 22.5,46.5
       parent: 1
-  - uid: 2091
+  - uid: 2149
     components:
     - type: Transform
       pos: 22.5,45.5
       parent: 1
-  - uid: 2092
+  - uid: 2150
     components:
     - type: Transform
       pos: 19.5,45.5
       parent: 1
-  - uid: 2093
+  - uid: 2151
     components:
     - type: Transform
       pos: 19.5,46.5
       parent: 1
-  - uid: 2094
+  - uid: 2152
     components:
     - type: Transform
       pos: 18.5,46.5
       parent: 1
-  - uid: 2095
+  - uid: 2153
     components:
     - type: Transform
       pos: 18.5,47.5
       parent: 1
-  - uid: 2096
+  - uid: 2154
     components:
     - type: Transform
       pos: -2.5,19.5
       parent: 1
-  - uid: 2097
+  - uid: 2155
     components:
     - type: Transform
       pos: -2.5,20.5
       parent: 1
-  - uid: 2098
+  - uid: 2156
     components:
     - type: Transform
       pos: -1.5,26.5
       parent: 1
-  - uid: 2099
+  - uid: 2157
     components:
     - type: Transform
       pos: -0.5,26.5
       parent: 1
-  - uid: 2100
+  - uid: 2158
     components:
     - type: Transform
       pos: 0.5,26.5
       parent: 1
-  - uid: 2101
+  - uid: 2159
     components:
     - type: Transform
       pos: -1.5,41.5
       parent: 1
-  - uid: 2102
+  - uid: 2160
     components:
     - type: Transform
       pos: -1.5,42.5
       parent: 1
-  - uid: 2103
+  - uid: 2161
     components:
     - type: Transform
       pos: -0.5,42.5
       parent: 1
-  - uid: 2104
+  - uid: 2162
     components:
     - type: Transform
       pos: 0.5,42.5
       parent: 1
-  - uid: 2105
+  - uid: 2163
     components:
     - type: Transform
       pos: 21.5,46.5
       parent: 1
-  - uid: 2106
+  - uid: 2164
     components:
     - type: Transform
       pos: 20.5,46.5
       parent: 1
-  - uid: 2107
+  - uid: 2165
     components:
     - type: Transform
       pos: -1.5,20.5
       parent: 1
-  - uid: 2108
+  - uid: 2166
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 1
-  - uid: 2109
+  - uid: 2167
     components:
     - type: Transform
       pos: 22.5,20.5
       parent: 1
-  - uid: 2110
+  - uid: 2168
     components:
     - type: Transform
       pos: -0.5,20.5
       parent: 1
-  - uid: 2111
+  - uid: 2169
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
-  - uid: 2112
+  - uid: 2170
     components:
     - type: Transform
       pos: 21.5,20.5
       parent: 1
-  - uid: 2113
+  - uid: 2171
     components:
     - type: Transform
       pos: 19.5,20.5
       parent: 1
-  - uid: 2114
+  - uid: 2172
     components:
     - type: Transform
       pos: 20.5,20.5
       parent: 1
-  - uid: 2115
+  - uid: 2173
     components:
     - type: Transform
       pos: 17.5,46.5
       parent: 1
-  - uid: 2116
+  - uid: 2174
     components:
     - type: Transform
       pos: 18.5,24.5
       parent: 1
-  - uid: 2117
+  - uid: 2175
     components:
     - type: Transform
       pos: 18.5,45.5
       parent: 1
-  - uid: 2118
+  - uid: 2176
     components:
     - type: Transform
       pos: 19.5,24.5
       parent: 1
-  - uid: 2119
+  - uid: 2177
     components:
     - type: Transform
       pos: 18.5,41.5
       parent: 1
-  - uid: 2120
+  - uid: 2178
     components:
     - type: Transform
       pos: 18.5,37.5
       parent: 1
-  - uid: 2121
+  - uid: 2179
     components:
     - type: Transform
       pos: 18.5,33.5
       parent: 1
-  - uid: 2122
+  - uid: 2180
     components:
     - type: Transform
       pos: 18.5,29.5
       parent: 1
-  - uid: 2123
+  - uid: 2181
     components:
     - type: Transform
       pos: 18.5,28.5
       parent: 1
-  - uid: 2124
+  - uid: 2182
     components:
     - type: Transform
       pos: 18.5,27.5
       parent: 1
-  - uid: 2125
+  - uid: 2183
     components:
     - type: Transform
       pos: 19.5,23.5
       parent: 1
-  - uid: 2126
+  - uid: 2184
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 1
-  - uid: 2127
+  - uid: 2185
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 1
-  - uid: 2128
+  - uid: 2186
     components:
     - type: Transform
       pos: -1.5,23.5
       parent: 1
-  - uid: 2129
+  - uid: 2187
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 1
-  - uid: 2130
+  - uid: 2188
     components:
     - type: Transform
       pos: 5.5,22.5
       parent: 1
-  - uid: 2131
+  - uid: 2189
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 1
-  - uid: 2132
+  - uid: 2190
     components:
     - type: Transform
       pos: 4.5,25.5
       parent: 1
-  - uid: 2133
+  - uid: 2191
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 1
-  - uid: 2134
+  - uid: 2192
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 2148
+  - uid: 2193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,19.5
       parent: 1
-  - uid: 2152
+  - uid: 2194
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,25.5
       parent: 1
-  - uid: 2154
+  - uid: 2195
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,19.5
       parent: 1
-  - uid: 2155
+  - uid: 2196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,19.5
       parent: 1
-  - uid: 2157
+  - uid: 2197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,19.5
       parent: 1
-  - uid: 2161
+  - uid: 2198
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,24.5
       parent: 1
-  - uid: 2162
+  - uid: 2199
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,25.5
       parent: 1
-  - uid: 2211
+  - uid: 2200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,5.5
       parent: 1
-  - uid: 2212
+  - uid: 2201
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,6.5
       parent: 1
-  - uid: 2213
+  - uid: 2202
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,7.5
       parent: 1
-  - uid: 2214
+  - uid: 2203
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,8.5
       parent: 1
-  - uid: 2215
+  - uid: 2204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,9.5
       parent: 1
-  - uid: 2216
+  - uid: 2205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,7.5
       parent: 1
-  - uid: 2217
+  - uid: 2206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 1
-  - uid: 2218
+  - uid: 2207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
-  - uid: 2219
+  - uid: 2208
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
-  - uid: 2220
+  - uid: 2209
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 1
-  - uid: 2221
+  - uid: 2210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 2222
+  - uid: 2211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,5.5
       parent: 1
-  - uid: 2232
+  - uid: 2212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,13.5
       parent: 1
-  - uid: 2233
+  - uid: 2213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,14.5
       parent: 1
-  - uid: 2234
+  - uid: 2214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,15.5
       parent: 1
-  - uid: 2235
+  - uid: 2215
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,16.5
       parent: 1
-  - uid: 2236
+  - uid: 2216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,15.5
       parent: 1
-  - uid: 2237
+  - uid: 2217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,16.5
       parent: 1
-  - uid: 2238
+  - uid: 2218
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,14.5
       parent: 1
-  - uid: 2239
+  - uid: 2219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,13.5
       parent: 1
-  - uid: 2244
+  - uid: 2220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,27.5
       parent: 1
-  - uid: 2249
+  - uid: 2221
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,15.5
       parent: 1
-  - uid: 2250
+  - uid: 2222
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,15.5
       parent: 1
-  - uid: 2251
+  - uid: 2223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,15.5
       parent: 1
-  - uid: 2260
+  - uid: 2224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,26.5
       parent: 1
-  - uid: 2261
+  - uid: 2225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,27.5
       parent: 1
-  - uid: 2264
+  - uid: 2226
     components:
     - type: Transform
       pos: 7.5,27.5
       parent: 1
-  - uid: 2286
+  - uid: 2227
     components:
     - type: Transform
       pos: -4.5,41.5
       parent: 1
-  - uid: 2302
+  - uid: 2228
     components:
     - type: Transform
       pos: -5.5,20.5
       parent: 1
-  - uid: 2303
+  - uid: 2229
     components:
     - type: Transform
       pos: -5.5,21.5
       parent: 1
-  - uid: 2304
+  - uid: 2230
     components:
     - type: Transform
       pos: -4.5,20.5
       parent: 1
-  - uid: 2314
+  - uid: 2231
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-  - uid: 2349
+  - uid: 2232
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,27.5
       parent: 1
-  - uid: 2350
+  - uid: 2233
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,27.5
       parent: 1
-  - uid: 2353
+  - uid: 2234
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,27.5
       parent: 1
-  - uid: 2354
+  - uid: 2235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,27.5
       parent: 1
-  - uid: 2355
+  - uid: 2236
     components:
     - type: Transform
       pos: -3.5,41.5
       parent: 1
-  - uid: 2356
+  - uid: 2237
     components:
     - type: Transform
       pos: -3.5,42.5
       parent: 1
-  - uid: 2357
+  - uid: 2238
     components:
     - type: Transform
       pos: -3.5,43.5
       parent: 1
-  - uid: 2358
+  - uid: 2239
     components:
     - type: Transform
       pos: -3.5,44.5
       parent: 1
-  - uid: 2359
+  - uid: 2240
     components:
     - type: Transform
       pos: -3.5,45.5
       parent: 1
-  - uid: 2360
+  - uid: 2241
     components:
     - type: Transform
       pos: -3.5,46.5
       parent: 1
-  - uid: 2361
+  - uid: 2242
     components:
     - type: Transform
       pos: -3.5,47.5
       parent: 1
-  - uid: 2362
+  - uid: 2243
     components:
     - type: Transform
       pos: -3.5,48.5
       parent: 1
-  - uid: 2363
+  - uid: 2244
     components:
     - type: Transform
       pos: -2.5,42.5
       parent: 1
-  - uid: 2364
+  - uid: 2245
     components:
     - type: Transform
       pos: -2.5,41.5
       parent: 1
-  - uid: 2370
+  - uid: 2246
     components:
     - type: Transform
       pos: -0.5,44.5
       parent: 1
-  - uid: 2371
+  - uid: 2247
     components:
     - type: Transform
       pos: -0.5,43.5
       parent: 1
-  - uid: 2372
+  - uid: 2248
     components:
     - type: Transform
       pos: -2.5,43.5
       parent: 1
-  - uid: 2376
+  - uid: 2249
     components:
     - type: Transform
       pos: 23.5,-17.5
       parent: 1
-  - uid: 2377
+  - uid: 2250
     components:
     - type: Transform
       pos: 23.5,-16.5
       parent: 1
-  - uid: 2378
+  - uid: 2251
     components:
     - type: Transform
       pos: 23.5,-15.5
       parent: 1
-  - uid: 2379
+  - uid: 2252
     components:
     - type: Transform
       pos: 22.5,-15.5
       parent: 1
-  - uid: 2380
+  - uid: 2253
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 2381
+  - uid: 2254
     components:
     - type: Transform
       pos: -2.5,-15.5
       parent: 1
-  - uid: 2382
+  - uid: 2255
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 2383
+  - uid: 2256
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 1
-  - uid: 2397
+  - uid: 2257
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,50.5
       parent: 1
-  - uid: 2398
+  - uid: 2258
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,15.5
       parent: 1
-  - uid: 2401
+  - uid: 2259
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,50.5
       parent: 1
-  - uid: 2402
+  - uid: 2260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,51.5
       parent: 1
-  - uid: 2403
+  - uid: 2261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,45.5
       parent: 1
-  - uid: 2404
+  - uid: 2262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,46.5
       parent: 1
-  - uid: 2405
+  - uid: 2263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,47.5
       parent: 1
-  - uid: 2406
+  - uid: 2264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,46.5
       parent: 1
-  - uid: 2407
+  - uid: 2265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,45.5
       parent: 1
-  - uid: 2408
+  - uid: 2266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,47.5
       parent: 1
-  - uid: 2409
+  - uid: 2267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,48.5
       parent: 1
-  - uid: 2410
+  - uid: 2268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,46.5
       parent: 1
-  - uid: 2411
+  - uid: 2269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,45.5
       parent: 1
-  - uid: 2412
+  - uid: 2270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,44.5
       parent: 1
-  - uid: 2413
+  - uid: 2271
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,44.5
       parent: 1
-  - uid: 2414
+  - uid: 2272
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,41.5
       parent: 1
-  - uid: 2415
+  - uid: 2273
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,40.5
       parent: 1
-  - uid: 2416
+  - uid: 2274
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,39.5
       parent: 1
-  - uid: 2417
+  - uid: 2275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,38.5
       parent: 1
-  - uid: 2418
+  - uid: 2276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,37.5
       parent: 1
-  - uid: 2419
+  - uid: 2277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,36.5
       parent: 1
-  - uid: 2420
+  - uid: 2278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,34.5
       parent: 1
-  - uid: 2421
+  - uid: 2279
     components:
     - type: Transform
       pos: 24.5,36.5
       parent: 1
-  - uid: 2422
+  - uid: 2280
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,33.5
       parent: 1
-  - uid: 2423
+  - uid: 2281
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,32.5
       parent: 1
-  - uid: 2425
+  - uid: 2282
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,30.5
       parent: 1
-  - uid: 2426
+  - uid: 2283
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,29.5
       parent: 1
-  - uid: 2430
+  - uid: 2284
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,25.5
       parent: 1
-  - uid: 2431
+  - uid: 2285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,24.5
       parent: 1
-  - uid: 2435
+  - uid: 2286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,20.5
       parent: 1
-  - uid: 2436
+  - uid: 2287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,19.5
       parent: 1
-  - uid: 2438
+  - uid: 2288
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,41.5
       parent: 1
-  - uid: 2439
+  - uid: 2289
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,40.5
       parent: 1
-  - uid: 2440
+  - uid: 2290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,39.5
       parent: 1
-  - uid: 2441
+  - uid: 2291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,38.5
       parent: 1
-  - uid: 2442
+  - uid: 2292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,37.5
       parent: 1
-  - uid: 2443
+  - uid: 2293
     components:
     - type: Transform
       pos: 24.5,32.5
       parent: 1
-  - uid: 2445
+  - uid: 2294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,34.5
       parent: 1
-  - uid: 2446
+  - uid: 2295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,33.5
       parent: 1
-  - uid: 2449
+  - uid: 2296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,30.5
       parent: 1
-  - uid: 2450
+  - uid: 2297
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,29.5
       parent: 1
-  - uid: 2451
+  - uid: 2298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,28.5
       parent: 1
-  - uid: 2452
+  - uid: 2299
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,27.5
       parent: 1
-  - uid: 2453
+  - uid: 2300
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,26.5
       parent: 1
-  - uid: 2454
+  - uid: 2301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,25.5
       parent: 1
-  - uid: 2455
+  - uid: 2302
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,24.5
       parent: 1
-  - uid: 2456
+  - uid: 2303
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,23.5
       parent: 1
-  - uid: 2457
+  - uid: 2304
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,22.5
       parent: 1
-  - uid: 2458
+  - uid: 2305
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,21.5
       parent: 1
-  - uid: 2459
+  - uid: 2306
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15328,749 +15741,749 @@ entities:
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 710
+  - uid: 2307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,28.5
       parent: 1
-  - uid: 1906
+  - uid: 2308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,24.5
       parent: 1
-  - uid: 1907
+  - uid: 2309
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,24.5
       parent: 1
-  - uid: 1911
+  - uid: 2310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,26.5
       parent: 1
-  - uid: 1912
+  - uid: 2311
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-12.5
       parent: 1
-  - uid: 1913
+  - uid: 2312
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-12.5
       parent: 1
-  - uid: 1914
+  - uid: 2313
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-3.5
       parent: 1
-  - uid: 1915
+  - uid: 2314
     components:
     - type: Transform
       pos: -9.5,-1.5
       parent: 1
-  - uid: 1916
+  - uid: 2315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,7.5
       parent: 1
-  - uid: 1917
+  - uid: 2316
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 1
-  - uid: 1918
+  - uid: 2317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 1919
+  - uid: 2318
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 1920
+  - uid: 2319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-3.5
       parent: 1
-  - uid: 1921
+  - uid: 2320
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-1.5
       parent: 1
-  - uid: 1922
+  - uid: 2321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 1923
+  - uid: 2322
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 1924
+  - uid: 2323
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,2.5
       parent: 1
-  - uid: 1925
+  - uid: 2324
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 1926
+  - uid: 2325
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 1927
+  - uid: 2326
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 1928
+  - uid: 2327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 1929
+  - uid: 2328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 1
-  - uid: 1930
+  - uid: 2329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 1
-  - uid: 1931
+  - uid: 2330
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 1932
+  - uid: 2331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 1933
+  - uid: 2332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 1934
+  - uid: 2333
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 1935
+  - uid: 2334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 1936
+  - uid: 2335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 1
-  - uid: 1937
+  - uid: 2336
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-4.5
       parent: 1
-  - uid: 1938
+  - uid: 2337
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 1939
+  - uid: 2338
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 1940
+  - uid: 2339
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 1941
+  - uid: 2340
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,-3.5
       parent: 1
-  - uid: 1942
+  - uid: 2341
     components:
     - type: Transform
       pos: 29.5,-3.5
       parent: 1
-  - uid: 1943
+  - uid: 2342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,-1.5
       parent: 1
-  - uid: 1944
+  - uid: 2343
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,-12.5
       parent: 1
-  - uid: 1945
+  - uid: 2344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,-1.5
       parent: 1
-  - uid: 1946
+  - uid: 2345
     components:
     - type: Transform
       pos: 25.5,7.5
       parent: 1
-  - uid: 1947
+  - uid: 2346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,7.5
       parent: 1
-  - uid: 1948
+  - uid: 2347
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-12.5
       parent: 1
-  - uid: 1949
+  - uid: 2348
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-3.5
       parent: 1
-  - uid: 1950
+  - uid: 2349
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-4.5
       parent: 1
-  - uid: 1951
+  - uid: 2350
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-5.5
       parent: 1
-  - uid: 1952
+  - uid: 2351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-1.5
       parent: 1
-  - uid: 1953
+  - uid: 2352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-0.5
       parent: 1
-  - uid: 1954
+  - uid: 2353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,0.5
       parent: 1
-  - uid: 1955
+  - uid: 2354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-0.5
       parent: 1
-  - uid: 1956
+  - uid: 2355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,-1.5
       parent: 1
-  - uid: 1957
+  - uid: 2356
     components:
     - type: Transform
       pos: 22.5,-3.5
       parent: 1
-  - uid: 1958
+  - uid: 2357
     components:
     - type: Transform
       pos: 21.5,-4.5
       parent: 1
-  - uid: 1959
+  - uid: 2358
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,-6.5
       parent: 1
-  - uid: 1960
+  - uid: 2359
     components:
     - type: Transform
       pos: 24.5,1.5
       parent: 1
-  - uid: 1961
+  - uid: 2360
     components:
     - type: Transform
       pos: 22.5,-6.5
       parent: 1
-  - uid: 1962
+  - uid: 2361
     components:
     - type: Transform
       pos: 23.5,-5.5
       parent: 1
-  - uid: 1963
+  - uid: 2362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-6.5
       parent: 1
-  - uid: 1964
+  - uid: 2363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,0.5
       parent: 1
-  - uid: 1965
+  - uid: 2364
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,1.5
       parent: 1
-  - uid: 1966
+  - uid: 2365
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,2.5
       parent: 1
-  - uid: 1967
+  - uid: 2366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,3.5
       parent: 1
-  - uid: 1968
+  - uid: 2367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,2.5
       parent: 1
-  - uid: 1969
+  - uid: 2368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,1.5
       parent: 1
-  - uid: 1970
+  - uid: 2369
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-22.5
       parent: 1
-  - uid: 1971
+  - uid: 2370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,-22.5
       parent: 1
-  - uid: 1972
+  - uid: 2371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-17.5
       parent: 1
-  - uid: 1973
+  - uid: 2372
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-16.5
       parent: 1
-  - uid: 1974
+  - uid: 2373
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-18.5
       parent: 1
-  - uid: 1975
+  - uid: 2374
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-18.5
       parent: 1
-  - uid: 1976
+  - uid: 2375
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-17.5
       parent: 1
-  - uid: 1977
+  - uid: 2376
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-22.5
       parent: 1
-  - uid: 1978
+  - uid: 2377
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,-22.5
       parent: 1
-  - uid: 1979
+  - uid: 2378
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-16.5
       parent: 1
-  - uid: 1980
+  - uid: 2379
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,23.5
       parent: 1
-  - uid: 1981
+  - uid: 2380
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,23.5
       parent: 1
-  - uid: 1982
+  - uid: 2381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,22.5
       parent: 1
-  - uid: 2135
+  - uid: 2382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-18.5
       parent: 1
-  - uid: 2136
+  - uid: 2383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-16.5
       parent: 1
-  - uid: 2137
+  - uid: 2384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-11.5
       parent: 1
-  - uid: 2138
+  - uid: 2385
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-11.5
       parent: 1
-  - uid: 2140
+  - uid: 2386
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,-18.5
       parent: 1
-  - uid: 2141
+  - uid: 2387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,11.5
       parent: 1
-  - uid: 2147
+  - uid: 2388
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 2149
+  - uid: 2389
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,15.5
       parent: 1
-  - uid: 2153
+  - uid: 2390
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,22.5
       parent: 1
-  - uid: 2156
+  - uid: 2391
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,15.5
       parent: 1
-  - uid: 2223
+  - uid: 2392
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,12.5
       parent: 1
-  - uid: 2224
+  - uid: 2393
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 1
-  - uid: 2225
+  - uid: 2394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,6.5
       parent: 1
-  - uid: 2226
+  - uid: 2395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 2227
+  - uid: 2396
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,6.5
       parent: 1
-  - uid: 2228
+  - uid: 2397
     components:
     - type: Transform
       pos: 21.5,8.5
       parent: 1
-  - uid: 2229
+  - uid: 2398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,4.5
       parent: 1
-  - uid: 2230
+  - uid: 2399
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 2231
+  - uid: 2400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,10.5
       parent: 1
-  - uid: 2240
+  - uid: 2401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,14.5
       parent: 1
-  - uid: 2241
+  - uid: 2402
     components:
     - type: Transform
       pos: 24.5,15.5
       parent: 1
-  - uid: 2242
+  - uid: 2403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,17.5
       parent: 1
-  - uid: 2243
+  - uid: 2404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,12.5
       parent: 1
-  - uid: 2245
+  - uid: 2405
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,14.5
       parent: 1
-  - uid: 2246
+  - uid: 2406
     components:
     - type: Transform
       pos: -4.5,17.5
       parent: 1
-  - uid: 2247
+  - uid: 2407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,15.5
       parent: 1
-  - uid: 2258
+  - uid: 2408
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,28.5
       parent: 1
-  - uid: 2262
+  - uid: 2409
     components:
     - type: Transform
       pos: 3.5,28.5
       parent: 1
-  - uid: 2263
+  - uid: 2410
     components:
     - type: Transform
       pos: 13.5,28.5
       parent: 1
-  - uid: 2265
+  - uid: 2411
     components:
     - type: Transform
       pos: 6.5,28.5
       parent: 1
-  - uid: 2270
+  - uid: 2412
     components:
     - type: Transform
       pos: 13.5,26.5
       parent: 1
-  - uid: 2305
+  - uid: 2413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,19.5
       parent: 1
-  - uid: 2306
+  - uid: 2414
     components:
     - type: Transform
       pos: -5.5,22.5
       parent: 1
-  - uid: 2307
+  - uid: 2415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,19.5
       parent: 1
-  - uid: 2312
+  - uid: 2416
     components:
     - type: Transform
       pos: -3.5,27.5
       parent: 1
-  - uid: 2313
+  - uid: 2417
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,23.5
       parent: 1
-  - uid: 2352
+  - uid: 2418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,18.5
       parent: 1
-  - uid: 2365
+  - uid: 2419
     components:
     - type: Transform
       pos: -4.5,42.5
       parent: 1
-  - uid: 2373
+  - uid: 2420
     components:
     - type: Transform
       pos: -2.5,44.5
       parent: 1
-  - uid: 2374
+  - uid: 2421
     components:
     - type: Transform
       pos: -0.5,45.5
       parent: 1
-  - uid: 2384
+  - uid: 2422
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-18.5
       parent: 1
-  - uid: 2385
+  - uid: 2423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-18.5
       parent: 1
-  - uid: 2386
+  - uid: 2424
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 2387
+  - uid: 2425
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-14.5
       parent: 1
-  - uid: 2388
+  - uid: 2426
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-18.5
       parent: 1
-  - uid: 2389
+  - uid: 2427
     components:
     - type: Transform
       pos: 22.5,-18.5
       parent: 1
-  - uid: 2427
+  - uid: 2428
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,21.5
       parent: 1
-  - uid: 2428
+  - uid: 2429
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,23.5
       parent: 1
-  - uid: 2429
+  - uid: 2430
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,28.5
       parent: 1
-  - uid: 2432
+  - uid: 2431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,26.5
       parent: 1
-  - uid: 2437
+  - uid: 2432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,19.5
       parent: 1
-  - uid: 2486
+  - uid: 2433
     components:
     - type: Transform
       pos: 22.5,49.5
       parent: 1
-  - uid: 2487
+  - uid: 2434
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,49.5
       parent: 1
-  - uid: 2488
+  - uid: 2435
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,48.5
       parent: 1
-  - uid: 2489
+  - uid: 2436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16078,253 +16491,253 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 2015
+  - uid: 2437
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 2016
+  - uid: 2438
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 2017
+  - uid: 2439
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 2018
+  - uid: 2440
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 2019
+  - uid: 2441
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 2020
+  - uid: 2442
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 2021
+  - uid: 2443
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-4.5
       parent: 1
-  - uid: 2022
+  - uid: 2444
     components:
     - type: Transform
       pos: 12.5,-1.5
       parent: 1
-  - uid: 2023
+  - uid: 2445
     components:
     - type: Transform
       pos: 13.5,-1.5
       parent: 1
-  - uid: 2024
+  - uid: 2446
     components:
     - type: Transform
       pos: 14.5,-1.5
       parent: 1
-  - uid: 2025
+  - uid: 2447
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 2026
+  - uid: 2448
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 2027
+  - uid: 2449
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 1
-  - uid: 2034
+  - uid: 2450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 1
-  - uid: 2035
+  - uid: 2451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-2.5
       parent: 1
-  - uid: 2036
+  - uid: 2452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-5.5
       parent: 1
-  - uid: 2037
+  - uid: 2453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-5.5
       parent: 1
-  - uid: 2038
+  - uid: 2454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-5.5
       parent: 1
-  - uid: 2039
+  - uid: 2455
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-0.5
       parent: 1
-  - uid: 2040
+  - uid: 2456
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 2041
+  - uid: 2457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 1
-  - uid: 2042
+  - uid: 2458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 1
-  - uid: 2043
+  - uid: 2459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-  - uid: 2044
+  - uid: 2460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-4.5
       parent: 1
-  - uid: 2045
+  - uid: 2461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-4.5
       parent: 1
-  - uid: 2046
+  - uid: 2462
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 2047
+  - uid: 2463
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-14.5
       parent: 1
-  - uid: 2048
+  - uid: 2464
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-14.5
       parent: 1
-  - uid: 2049
+  - uid: 2465
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-13.5
       parent: 1
-  - uid: 2050
+  - uid: 2466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 1
-  - uid: 2051
+  - uid: 2467
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-0.5
       parent: 1
-  - uid: 2052
+  - uid: 2468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-0.5
       parent: 1
-  - uid: 2053
+  - uid: 2469
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
       parent: 1
-  - uid: 2054
+  - uid: 2470
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-0.5
       parent: 1
-  - uid: 2055
+  - uid: 2471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 1
-  - uid: 2056
+  - uid: 2472
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-6.5
       parent: 1
-  - uid: 2057
+  - uid: 2473
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-6.5
       parent: 1
-  - uid: 2058
+  - uid: 2474
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-6.5
       parent: 1
-  - uid: 2059
+  - uid: 2475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
-  - uid: 2060
+  - uid: 2476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-8.5
       parent: 1
-  - uid: 2061
+  - uid: 2477
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-7.5
       parent: 1
-  - uid: 2062
+  - uid: 2478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 1
-  - uid: 2063
+  - uid: 2479
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-10.5
       parent: 1
-  - uid: 2064
+  - uid: 2480
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16332,43 +16745,43 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 2139
+  - uid: 2481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-16.5
       parent: 1
-  - uid: 2143
+  - uid: 2482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 2144
+  - uid: 2483
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 2145
+  - uid: 2484
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 2146
+  - uid: 2485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,2.5
       parent: 1
-  - uid: 2151
+  - uid: 2486
     components:
     - type: Transform
       pos: 17.5,47.5
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 2158
+  - uid: 2487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16376,37 +16789,30 @@ entities:
       parent: 1
 - proto: WaterCooler
   entities:
-  - uid: 2159
+  - uid: 2488
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-- proto: WeaponRifleAk
-  entities:
-  - uid: 2160
-    components:
-    - type: Transform
-      pos: 13.549298,-4.6064243
-      parent: 1
 - proto: WeaponTurretAK570
   entities:
-  - uid: 2166
+  - uid: 2490
     components:
     - type: Transform
       pos: 20.5,-19.5
       parent: 1
-  - uid: 2167
+  - uid: 2491
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
-  - uid: 2433
+  - uid: 2492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,22.5
       parent: 1
-  - uid: 2434
+  - uid: 2493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16414,19 +16820,19 @@ entities:
       parent: 1
 - proto: WeaponTurretBofors
   entities:
-  - uid: 2163
+  - uid: 2494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,8.5
       parent: 1
-  - uid: 2164
+  - uid: 2495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,8.5
       parent: 1
-  - uid: 2165
+  - uid: 2496
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16434,7 +16840,7 @@ entities:
       parent: 1
 - proto: WeaponTurretKargil
   entities:
-  - uid: 2268
+  - uid: 2497
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -593,9 +593,15 @@
     sprite: Clothing/Belt/holster.rsi
   - type: Clothing
     sprite: Clothing/Belt/holster.rsi
-  # - type: Storage # Frontier: commented out
-    # grid: # Frontier: commented out
-    # - 0,0,3,1 # Frontier: commented out
+  - type: Storage # Frontier: commented out
+    maxItemSize: Huge # Frontier: commented out
+    grid: # Frontier: commented out
+    - 0,0,3,3 # Frontier: commented out
+    whitelist: # Frontier: commented out whitelist
+     components:
+     - Gun
+     - BallisticAmmoProvider
+     - CartridgeAmmo
 
 - type: entity
   parent: [NFClothingBeltStorageBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
@@ -607,17 +613,17 @@
     sprite: Clothing/Belt/syndieholster.rsi
   - type: Clothing
     sprite: Clothing/Belt/syndieholster.rsi
-  #- type: Item # Frontier
-    #size: Ginormous # Frontier
-  # - type: Storage # Frontier: commented out
-    # maxItemSize: Huge # Frontier: commented out
-    # grid: # Frontier: commented out
-    # - 0,0,3,3 # Frontier: commented out
-    # whitelist: # Frontier: commented out whitelist
-      # components:
-        # - Gun
-        # - BallisticAmmoProvider
-        # - CartridgeAmmo
+  - type: Item # Frontier
+    size: Ginormous # Frontier
+  - type: Storage # Frontier: commented out
+    maxItemSize: Huge # Frontier: commented out
+    grid: # Frontier: commented out
+    - 0,0,4,3 # Frontier: commented out
+    whitelist: # Frontier: commented out whitelist
+     components:
+     - Gun
+     - BallisticAmmoProvider
+     - CartridgeAmmo
 
 - type: entity
   parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -50,7 +50,6 @@
         whitelist:
           tags:
           - Knife
-          - Sidearm
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -101,4 +101,6 @@
   - type: Item
     heldPrefix: blackkit
     size: Normal
+  - type: Clothing
+    slots: pocket
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -40,3 +40,45 @@
         volume: -1
   - type: StaticPrice
     price: 1
+
+- type: entity
+  id: BaseCartridgeGrenade
+  parent: BaseItem
+  abstract: true
+  components:
+  - type: Sprite
+    drawdepth: Items
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.10,-0.05,0.10,0.05"
+        density: 20
+        mask:
+          - ItemMask
+        restitution: 0.3  # fite me
+        friction: 0.2
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StrongMetallic # We only want explosions breaking them (for the most part)
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Tag
+    tags:
+    - Cartridge
+  - type: Item
+    size: Tiny
+  - type: EmitSoundOnLand
+    sound:
+      path: /Audio/Weapons/Guns/Casings/casing_fall_2.ogg
+      params:
+        volume: -1
+  - type: StaticPrice
+    price: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/grenade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/grenade.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazineGrenade
   name: grenade cartridge
-  parent: [ BaseCartridge, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [ BaseCartridgeGrenade, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -836,9 +836,15 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 150 # a ~2 tile radius
-    intensitySlope: 5
-    maxIntensity: 10
+    totalIntensity: 250 #150 # a ~2 tile radius
+    intensitySlope: 5 #5
+    maxIntensity: 100 #10
+  - type: Projectile # Wasn't, couldn't penetrate any entity (MONO still fixing it)
+    damage:
+      types:
+        Blunt: 200
+        Heat: 100
+        Structural: 400
 
 - type: entity
   id: BulletGrenadeFlash

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -35,6 +35,14 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: StrongMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1500 #500 For Mono by salo
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
   - type: ContainerFill
     containers:
       board: [ DoorElectronics ]

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -77,14 +77,14 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 900 #150 - Mono balance buff by salo
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
         - !type:DoActsBehavior
           acts: ["Destruction"]
   - type: Gun
-    fireRate: 3
+    fireRate: 6 #3
     useKey: false
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ship_svalinn.ogg
@@ -110,7 +110,7 @@
             - PowerCellSmall
   - type: HitscanBatteryAmmoProvider
     proto: NFRedLightLaser # Frontier: use NF prefix
-    fireCost: 50
+    fireCost: 10 #50
 
 - type: entity
   id: ShuttleGunPerforator
@@ -139,14 +139,14 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 1200 #300
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
         - !type:DoActsBehavior
           acts: ["Destruction"]
   - type: Gun
-    fireRate: 1
+    fireRate: 2
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ship_perforator.ogg
       params:
@@ -170,7 +170,7 @@
             - PowerCage
   - type: HitscanBatteryAmmoProvider
     proto: NFRedShuttleLaser # Frontier: use NF variant
-    fireCost: 150
+    fireCost: 50 #150
 
 # ---- Launchers ----
 # naming: EXP (Explosion) + conventional power + suffix (g for Grenade, c for RPG Cartridge) + Name
@@ -199,15 +199,15 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 900 #200
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
         - !type:DoActsBehavior
           acts: ["Destruction"]
   - type: Gun
-    projectileSpeed: 80
-    fireRate: 1
+    projectileSpeed: 120 #80
+    fireRate: 2
     angleDecay: 45
     minAngle: 0
     maxAngle: 15
@@ -221,7 +221,7 @@
     whitelist:
       tags:
         - Grenade
-    capacity: 2
+    capacity: 8
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
   - type: Machine
@@ -254,14 +254,14 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 350
+        damage: 1200 #350
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
         - !type:DoActsBehavior
           acts: ["Destruction"]
   - type: Gun
-    projectileSpeed: 40
+    projectileSpeed: 200 #40
     fireRate: 0.3
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ship_duster.ogg
@@ -313,7 +313,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 2000 #300
       behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]
@@ -322,14 +322,14 @@
     layers:
     - state: base
   - type: Gun
-    fireRate: 1
+    fireRate: 0.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mateba.ogg
   - type: BallisticAmmoProvider
     whitelist:
       tags:
         - CannonBall
-    capacity: 1
+    capacity: 2
     proto: NFCannonBall # Frontier: use NF variant
     soundInsert:
       path: /Audio/Weapons/Guns/Gunshots/grenade_launcher.ogg
@@ -365,14 +365,14 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 650 #100
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
         - !type:DoActsBehavior
           acts: ["Destruction"]
   - type: Gun
-    projectileSpeed: 20
+    projectileSpeed: 35 #20
     fireRate: 2
     selectedMode: SemiAuto
     angleDecay: 45
@@ -385,18 +385,18 @@
       params:
         variation: 0.12
   - type: RechargeBasicEntityAmmo
-    rechargeCooldown: 3
+    rechargeCooldown: 2 #3
     rechargeSound:
       path: /Audio/Weapons/Guns/Bolt/lmg_bolt_closed.ogg
       params:
         pitch: 1.2
         variation: 0.08
   - type: BasicEntityAmmoProvider
-    proto: NFBulletKineticShuttle
-    capacity: 10
-    count: 10
+    proto: NFBulletKineticMediumPower #NFBulletKineticShuttle<NFBulletKineticMediumPower
+    capacity: 5 #10
+    count: 5 #10
   - type: Machine
     board: ShuttleGunKineticCircuitboard
   - type: ExtensionCableReceiver # Frontier
   - type: ApcPowerReceiver # Frontier
-    powerLoad: 1500 # Frontier
+    powerLoad: 2500 #1500 # Frontier

--- a/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
+++ b/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
@@ -331,7 +331,7 @@
   result: PowerCageRechargerCircuitboard
 
 - type: latheRecipe
-  parent: [ BaseCircuitboardRecipe, BaseSecurityMachineRecipeCategory ]
+  parent: [ BaseGoldCircuitboardRecipe, BaseSecurityMachineRecipeCategory ]
   id: ShuttleGunKineticCircuitboard
   result: ShuttleGunKineticCircuitboard
   completetime: 6

--- a/Resources/Prototypes/_Lua/Entities/Objects/Weapons/Guns/SpaceArtillery/Ammunition/Projectiles/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Lua/Entities/Objects/Weapons/Guns/SpaceArtillery/Ammunition/Projectiles/Energy/projectiles.yml
@@ -11,16 +11,16 @@
   - type: Projectile
     damage:
       types:
-        Structural: 175
+        Structural: 1000 #175
         Radiation: 35
-        Heat: 40
-        Blunt: 20
+        Heat: 80 #40
+        Blunt: 40 #20
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
-    maxIntensity: 12
-    intensitySlope: 3
-    totalIntensity: 4
+    explosionType: MicroBomb #Default
+    maxIntensity: 40 #12
+    intensitySlope: 6 #3
+    totalIntensity: 40 #4
     maxTileBreak: 2
   - type: PointLight
     radius: 3.5
@@ -35,7 +35,7 @@
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
-    lifetime: 20
+    lifetime: 7 #20
   - type: ShipWeaponProjectile
 
 - type: hitscan

--- a/Resources/Prototypes/_Lua/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/_Lua/Entities/Structures/Shuttles/thrusters.yml
@@ -62,8 +62,6 @@
   name: ракетный двигатель
   suffix: LuaTech, Луа, Тир 5
   components:
-  - type: DisableToolUse
-    prying: true
   - type: Machine
     board: ThrusterLuaMachineCircuitboard
   - type: Sprite

--- a/Resources/Prototypes/_Lua/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/_Lua/Entities/Structures/Shuttles/thrusters.yml
@@ -62,6 +62,8 @@
   name: ракетный двигатель
   suffix: LuaTech, Луа, Тир 5
   components:
+  - type: DisableToolUse
+    prying: true
   - type: Machine
     board: ThrusterLuaMachineCircuitboard
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -14,6 +14,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Shotguns/bulldog.rsi
   - type: Gun
+    fireRate: 3
     selectedMode: FullAuto
     availableModes:
     - FullAuto
@@ -35,6 +36,8 @@
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun_inhands_64x.rsi
   - type: BallisticAmmoProvider
     capacity: 2
+  - type: Gun
+    fireRate: 2
   - type: Construction
     graph: NFShotgunSawn
     node: start
@@ -72,6 +75,8 @@
     sprite: _NF/Objects/Weapons/Guns/Shotguns/pump_inhands_64x.rsi
   - type: BallisticAmmoProvider
     capacity: 5
+  - type: Gun
+    fireRate: 1
   - type: NFWeaponDetails
     manufacturer: weapon-details-manufacturer-nanotrasen-munitions
 
@@ -88,6 +93,8 @@
     sprite: _DV/Objects/Weapons/Guns/Shotguns/sawn.rsi
   - type: Item
     size: Small
+  - type: Gun
+    fireRate: 2
   - type: BallisticAmmoProvider
     capacity: 2
   - type: NFWeaponDetails

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/5mm.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/5mm.yml
@@ -12,7 +12,8 @@
     whitelist:
       tags:
         - N14CartridgePistol5
-    capacity: 0
+    proto: N14CartridgePistol5
+    capacity: 200
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container
@@ -24,7 +25,12 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+  - type: MagazineVisuals
+    magState: mag
+    steps: 2
+    zeroVisible: false
   - type: Appearance
+
 
 - type: entity
   id: N14MagazineMinigun5mm
@@ -32,5 +38,4 @@
   parent: N14BaseMagazine5mmMinigun
   components:
   - type: BallisticAmmoProvider
-    capacity: 200
     proto: N14CartridgePistol5


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/ru/getting-started/pr-guideline -->
<!-- Сообщения со стрелочками это комментарии, их не будет видно -->

## О пулл-реквесте
<!-- Что вы изменили? --> Кобуры имеют больше вместимости как было на старом фронтире только для вооружения.
Двигатели lua Т5 компонентов нельзя теперь разобрать, т.е. т5 компачи за "бесплатно" и "раундстартом" не достать.
Дастеры стали в разы полезнее в корабельных схватках - ребаланс. Так-же "Картридж" не удаляется, добавил второй парент без SpaceTrash в ту-же папку что-бы пустые гильзы удалялись, но не гранатомётные.
PTK-800 "Дематериализатор материи - дропает руду + ребаланс + усложнение крафта.
Боевую аптечку можно носить на подсумке! [LuaWorld уже как 3 месяца живёт с этим]
Крафт пустой обоймы минигана теперь рабочая и ее можно заряжать + исправлен визуал от пустой и полной.
В боевые ботинки нельзя засунуть огнестрел, бульдог в ботинке - пиздееееееец.
Дробовики теперь не 1.5 скорострельности, а имеют ребаланс как было ранее старого Фронтира.
Импусльное корабельное орудие теперь не говнище, а способное нанести хороший вред.
Качество жизни в общем-то говоря.
<!-- Если это изменение кода, кратко опишите как работает ваш новый код. Это упростит проверку. -->

## Обоснование / Баланс
<!-- Обсудите как это повлияет на игровой баланс или объясните причину изменения. Приведите ссылки на обсуждения или issues. -->

## Технические детали
<!-- Краткое описание изменений в коде для удобства проверки. -->

## Как протестировать
<!-- Опишите процедуру тестирования этой функции с ожидаемым результатом/поведением. -->

## Медиа
<!-- Приложите скриншоты/видео, если PR вносит изменения в игру (одежда, предметы, фичи и т.д.). 
Мелкие правки/рефакторинг не требуют. Медиа могут быть использованы в отчетах о разработке SS14 с указанием авторства. -->

## Требования
<!-- Подтвердите следующее, поставив X в квадратных скобках [X]: -->
- [X] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я приложил медиа-материалы к этому PR или они не требуются.
- [X] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [X] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.
<!-- Имейте в виду, что несоблюдение этих требований может привести к закрытию PR по усмотрению мейнтейнера -->

## Критические изменения
<!-- Перечислите любые критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименование прототипов; и предоставьте инструкции по их исправлению. -->

**Журнал изменений**
<!-- Добавьте запись в журнал изменений, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на геймплей.
Убедитесь, что прочитали руководство и удалите этот шаблон из комментария, чтобы он отобразился.
Запись должна содержать символ :cl:, чтобы бот распознал изменения и добавил их в игровой журнал изменений. -->

:cl:
- remove: В армейские ботинки нельзя засовывать огнестрел.
- tweak: Плечевая кобура/кобура синдиката имеют больше вместимости с фильтром на обоймы/огнестрел.
- tweak: Боевую аптечку можно повесить на карман.
- tweak: Гермозатвор стал в трое крепче.
- tweak: Корабельный Импульсный Лазер был бафнут.
- tweak: "PTK-800 Дематериализатор материи" дропает руду, усложнён крафт.
- fix: Луа Т5 ракетный двигатель нельзя теперь разобрать.
- fix: Гранатомётные картриджи не исчезают.
- fix: Напечатанная версия обоймы для минигана рабочая.
- fix: Все дробовики имели одинаковую скорострельность.
- fix: Стыковочные шлюзы пиратов чёрной верфи теперь имеют доступы для всех, а не "Тайпановские".

