### PR TITLE
улучшение визора рейнджеров

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -305,6 +305,16 @@
   - type: FlashImmunity
   - type: EyeProtection
     protectionTime: 5
+  - type: ThermalVision
+    flashDurationMultiplier: 2
+    pulseTime: 1
+    isEquipment: true
+    color: "#DC143C"
+    toggleAction: ToggleThermalVision
+  - type: NightVision
+    isEquipment: true
+    color: "#00BFFF"
+    toggleAction: ToggleNightVision
 
 - type: entity
   parent: [ClothingEyesEyepatchHudDiag, ClothingHeadEyeBaseFlipped]


### PR DESCRIPTION
## О пулл-реквесте
Добавил в универсальный визор используемый рейнджерами ПНВ и Термальный Визор

## Обоснование / Баланс
Уберет проблему которая заключается в том что пираты/Нордфолл ломают все лампы на торговом и рейнджеры из-за того что нету ПНВ и термального визора имеют проблему с тем что не видят почти ничего а еще это попросту не логично что даже у пиратов и синди есть хотя-бы термальный визор а у Элитного отряда рейнджеров нету

## Как протестировать
заспавнить универсальный визор и надеть в слот очков

## Требования
<!-- Подтвердите следующее, поставив X в квадратных скобках [X]: -->
- [x] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я приложил медиа-материалы к этому PR или они не требуются.
- [x] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [x] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.
<!-- Имейте в виду, что несоблюдение этих требований может привести к закрытию PR по усмотрению мейнтейнера -->


**Журнал изменений**
<!-- Добавьте запись в журнал изменений, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на геймплей.
Убедитесь, что прочитали руководство и удалите этот шаблон из комментария, чтобы он отобразился.
Запись должна содержать символ :cl:, чтобы бот распознал изменения и добавил их в игровой журнал изменений. -->

<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->

:cl:
- add: Добавил в универсальный визор используемый рейнджерами ПНВ и Термальный Визор