### PR TITLE
Исправление датчиков

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Station.Systems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Clothing;
 using Content.Shared.Damage;
+using Content.Server.GameTicking;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -48,6 +49,8 @@ public sealed class SuitSensorSystem : EntitySystem
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
+
+    [Dependency] private readonly GameTicking.GameTicker _ticker = default!; // Added to check run level
 
     public override void Initialize()
     {
@@ -175,10 +178,16 @@ public sealed class SuitSensorSystem : EntitySystem
         component.StationId ??= _stationSystem.GetOwningStation(uid);
         */
 
-        // generate random mode
+        // Если предмет со встроенными датчиками появляется в течение раунда, ставим режим "Координаты".
+        if (_ticker.RunLevel == GameRunLevel.InRound)
+        {
+            SetSensor((uid, component), SuitSensorMode.SensorCords);
+            return;
+        }
+
+        // Иначе (до старта раунда) оставляем прототипное поведение (рандом).
         if (component.RandomMode)
         {
-            //make the sensor mode favor higher levels, except coords.
             var modesDist = new[]
             {
                 SuitSensorMode.SensorOff,

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -8,7 +8,7 @@ using Content.Server.Station.Systems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Clothing;
 using Content.Shared.Damage;
-using Content.Server.GameTicking;
+using Content.Server.GameTicking; //Lua
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -50,7 +50,7 @@ public sealed class SuitSensorSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
 
-    [Dependency] private readonly GameTicking.GameTicker _ticker = default!; // Added to check run level
+    [Dependency] private readonly GameTicking.GameTicker _ticker = default!; //Lua Added to check run level
 
     public override void Initialize()
     {
@@ -178,10 +178,10 @@ public sealed class SuitSensorSystem : EntitySystem
         component.StationId ??= _stationSystem.GetOwningStation(uid);
         */
 
-        // Если предмет со встроенными датчиками появляется в течение раунда, ставим режим "Координаты".
+        //Lua: if an item with built-in sensors spawns during the round - force Coordinates mode
         if (_ticker.RunLevel == GameRunLevel.InRound)
         {
-            SetSensor((uid, component), SuitSensorMode.SensorCords);
+            SetSensor((uid, component), SuitSensorMode.SensorCords); //Lua: default to coordinates so medics can find players
             return;
         }
 

--- a/Content.Server/_Lua/Medical/SuitSensors/AutoSuitSensorDefaultsSystem.cs
+++ b/Content.Server/_Lua/Medical/SuitSensors/AutoSuitSensorDefaultsSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.GameTicking;
 using Content.Server.Medical.SuitSensors;
+using Content.Server._NF.Medical.SuitSensors; //Lua
 using Content.Server.Access.Systems;
 using Content.Shared.Access.Components;
 using Content.Shared.Inventory;

--- a/Content.Server/_Lua/Medical/SuitSensors/AutoSuitSensorDefaultsSystem.cs
+++ b/Content.Server/_Lua/Medical/SuitSensors/AutoSuitSensorDefaultsSystem.cs
@@ -51,8 +51,8 @@ public sealed class AutoSuitSensorDefaultsSystem : EntitySystem
             //Lua: exclude by job icon/access tags (Syndicate/Pirate/Merc)
             if (_idCard.TryFindIdCard(wearer, out var delayedId))
             {
-                //Lua: job icon check (avoid ToString() on nullable string)
-                var jobIconStr = delayedId.Comp.JobIcon; //Lua: fix possible NRE by using the string directly
+                //Lua: job icon check using string id
+                var jobIconStr = delayedId.Comp.JobIcon.Id;
                 if (!string.IsNullOrEmpty(jobIconStr)) //Lua: guard against null/empty
                 {
                     //Lua: mercenary

--- a/Content.Server/_NF/Medical/SuitSensors/AutoSuitSensorDefaultsSystem.cs
+++ b/Content.Server/_NF/Medical/SuitSensors/AutoSuitSensorDefaultsSystem.cs
@@ -1,0 +1,110 @@
+using Content.Server.GameTicking;
+using Content.Server.Medical.SuitSensors;
+using Content.Server.Access.Systems;
+using Content.Shared.Access.Components;
+using Content.Shared.Inventory;
+using Content.Shared.Medical.SuitSensor;
+using Content.Shared.Roles;
+using Robust.Shared.Timing;
+
+namespace Content.Server._NF.Medical.SuitSensors;
+
+/// <summary>
+/// Sets default behavior for suit sensors:
+/// - For any clothing with sensors spawned during the round, default to Coordinates mode.
+/// - On roundstart starting gear equip, turn sensors ON for everyone except pirates, syndicates, and mercenaries.
+/// </summary>
+public sealed class AutoSuitSensorDefaultsSystem : EntitySystem
+{
+    [Dependency] private readonly GameTicker _ticker = default!;
+    [Dependency] private readonly SuitSensorSystem _suitSensors = default!;
+    [Dependency] private readonly IdCardSystem _idCard = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // После экипировки стартового снаряжения включаем датчики для подходящих ролей.
+        SubscribeLocalEvent<StartingGearEquippedEvent>(OnStartingGearEquipped);
+    }
+
+    private void OnStartingGearEquipped(ref StartingGearEquippedEvent args)
+    {
+        var wearer = args.Entity;
+
+        // Делаем действие чуть позже, чтобы все job specials (включая компонент пиратов) успели примениться.
+        Timer.Spawn(TimeSpan.FromMilliseconds(100), () =>
+        {
+            // Пираты: датчики должны быть выключены.
+            if (HasComp<DisableSuitSensorsComponent>(wearer))
+            {
+                _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorOff, SlotFlags.All);
+                return;
+            }
+
+            // Синдикаты (ядерные оперативники): датчики выключены.
+            if (HasComp<Content.Shared.NukeOps.NukeOperativeComponent>(wearer))
+            {
+                _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorOff, SlotFlags.All);
+                return;
+            }
+
+            // Синдикаты/пираты/мерки: проверяем иконку работы и теги доступа на ID.
+            if (_idCard.TryFindIdCard(wearer, out var delayedId))
+            {
+                // Проверка иконок работ
+                var jobIcon = delayedId.Comp.JobIcon;
+                var jobIconStr = jobIcon.ToString();
+                if (!string.IsNullOrEmpty(jobIconStr))
+                {
+                    // Mercenary
+                    if (jobIconStr == "JobIconMercenary")
+                    {
+                        _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorOff, SlotFlags.All);
+                        return;
+                    }
+                    // Syndicate (любые варианты, начинающиеся с JobIconSyndicate)
+                    if (jobIconStr.StartsWith("JobIconSyndicate"))
+                    {
+                        _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorOff, SlotFlags.All);
+                        return;
+                    }
+                    // Pirates (любой из JobIconNFPirate*)
+                    if (jobIconStr.StartsWith("JobIconNFPirate"))
+                    {
+                        _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorOff, SlotFlags.All);
+                        return;
+                    }
+                }
+
+                // Проверка тегов доступа
+                if (TryComp<AccessComponent>(delayedId.Owner, out var delayedAccess))
+                {
+                    // Mercenary
+                    if (delayedAccess.Tags.Contains("Mercenary"))
+                    {
+                        _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorOff, SlotFlags.All);
+                        return;
+                    }
+                    // Syndicate/NFSyndicate
+                    if (delayedAccess.Tags.Contains("Syndicate") || delayedAccess.Tags.Contains("NFSyndicate"))
+                    {
+                        _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorOff, SlotFlags.All);
+                        return;
+                    }
+                    // Pirates
+                    if (delayedAccess.Tags.Contains("Pirate"))
+                    {
+                        _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorOff, SlotFlags.All);
+                        return;
+                    }
+                }
+            }
+
+            // По умолчанию на раундстарте включаем датчики (Vitals) всем остальным.
+            _suitSensors.SetAllSensors(wearer, SuitSensorMode.SensorVitals, SlotFlags.All);
+        });
+    }
+}
+
+


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/ru/getting-started/pr-guideline -->
<!-- Сообщения со стрелочками это комментарии, их не будет видно -->

## О пулл-реквесте
- Сделала так, что у всей одежды (кроме пиратов, синдикатов и мерков) датчики теперь включены по умолчанию на старте раунда.
- Любая одежда, выданная, созданная или купленная в течение раунда, теперь всегда имеет датчики в режиме "Координаты". Изменение сделано специально для новичков, которые не умели включать датчики.

## Обоснование / Баланс
- Новички часто забывали включать датчики, из-за чего их не могли найти медики.
- Теперь датчики всегда включены, что упростит поиск и спасение игроков.
- Исключения — пираты, синдикаты и мерки, у них датчики по-прежнему выключены.

## Технические детали
- Добавлена серверная система, которая включает датчики на старте раунда для всех, кроме исключённых ролей.
- Для всей одежды, появляющейся в раунде, датчики автоматически ставятся в режим "Координаты".
- Проверка исключений реализована через иконку работы и теги доступа на ID.

## Как протестировать
- Запустить сервер, зайти за любую обычную профессию — датчики должны быть включены.
- Взять одежду из автомата, купить или создать — датчики сразу в режиме "Координаты".
- Зайти за пирата, синдиката или мерка — датчики выключены.

## Медиа
- Скриншоты не требуются, визуальных изменений нет.

## Требования
- [x] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [] Я приложил медиа-материалы к этому PR или они не требуются.
- [] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.

## Критические изменения
- Нет.

**Журнал изменений**
:cl:
- add: Датчики на одежде теперь включены по умолчанию для всех, кроме пиратов, синдикатов и мерков. Одежда, появившаяся в раунде, всегда с датчиками в режиме "Координаты".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Новые возможности
  - Автоматическая настройка датчиков костюмов при выдаче стартового снаряжения: по умолчанию для обычных ролей включается режим передачи жизненных показателей; для специальных ролей/антогонистов датчики отключаются.
- Изменения поведения
  - В начале и во время раунда датчики по умолчанию устанавливаются в режим передачи координат вместо случайной инициализации.
- Прочее
  - Логика применения настроек выполняется с небольшой задержкой при экипировке для корректной проверки карты и идентификационных данных.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->