### PR TITLE
Concord-Venture-SmallRemap

### DIFF
--- a/Resources/Maps/_Lua/Shuttles/Expedition/Concord-Venture.yml
+++ b/Resources/Maps/_Lua/Shuttles/Expedition/Concord-Venture.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 261.2.0
   forkId: ""
   forkVersion: ""
-  time: 09/24/2025 09:37:00
-  entityCount: 490
+  time: 09/25/2025 15:06:05
+  entityCount: 492
 maps: []
 grids:
 - 1
@@ -583,6 +583,15 @@ entities:
       - 272
       - 279
       - 22
+  - uid: 492
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 278
 - proto: AirCanister
   entities:
   - uid: 3
@@ -2422,6 +2431,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 12.5,7.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 492
   - uid: 279
     components:
     - type: Transform
@@ -2672,6 +2684,13 @@ entities:
     - type: Transform
       pos: 12.5,6.5
       parent: 1
+- proto: MachineFTLDrive600
+  entities:
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
 - proto: MedicalBed
   entities:
   - uid: 319
@@ -2719,7 +2738,7 @@ entities:
   - uid: 325
     components:
     - type: Transform
-      pos: -1.6043968,5.7644086
+      pos: -1.5377998,5.6899924
       parent: 1
   - uid: 326
     components:
@@ -3568,123 +3587,118 @@ entities:
       rot: 3.141592653589793 rad
       pos: 8.5,3.5
       parent: 1
-  - uid: 487
-    components:
-    - type: Transform
-      pos: 5.5,3.5
-      parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 466
+  - uid: 467
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 467
+  - uid: 468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 468
+  - uid: 469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,8.5
       parent: 1
-  - uid: 469
+  - uid: 470
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 470
+  - uid: 471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 471
+  - uid: 472
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 472
+  - uid: 473
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 473
+  - uid: 474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-  - uid: 474
+  - uid: 475
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 475
+  - uid: 476
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,1.5
       parent: 1
-  - uid: 476
+  - uid: 477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 1
-  - uid: 477
+  - uid: 478
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,2.5
       parent: 1
-  - uid: 478
+  - uid: 479
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,4.5
       parent: 1
-  - uid: 479
+  - uid: 480
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 1
-  - uid: 480
+  - uid: 481
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 481
+  - uid: 482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,11.5
       parent: 1
-  - uid: 482
+  - uid: 483
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 483
+  - uid: 484
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,9.5
       parent: 1
-  - uid: 484
+  - uid: 485
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 485
+  - uid: 486
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3692,13 +3706,19 @@ entities:
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 486
+  - uid: 487
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
 - proto: WindoorSecure
   entities:
+  - uid: 466
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 1
   - uid: 488
     components:
     - type: Transform


### PR DESCRIPTION
## О пулл-реквесте
Вернул БСС (теперь 600м) и добавил воздушную сигнализацию в РнД

## Обоснование / Баланс
Экспедиционный корабль без БСС двигателя... Уэ...

## Технические детали
изменён файл по пути: Maps/_Lua/Shuttles/Expidition/Concord-Venture.yml

## Как протестировать
купить/заспавнить

## Медиа

<img width="1105" height="773" alt="image" src="https://github.com/user-attachments/assets/c9095646-f238-4421-8a7c-c62308b09920" />


## Требования
- [x] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я приложил медиа-материалы к этому PR или они не требуются.
- [x] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [x] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.

**Журнал изменений**

:cl:
- tweak: Concord-Venture теперь снова имеет на борту БСС двигатель.
