### PR TITLE
Гост-роли котиков

### DIFF
--- a/Resources/Locale/ru-RU/_NF/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/ru-RU/_NF/ghost/roles/ghost-role-component.ftl
@@ -34,6 +34,13 @@ ghost-role-information-punk-boss-dungeon-name = Лидер панк-банды
 ghost-role-information-punk-boss-dungeon-description = Защищайте этот комплекс и свою добычу вместе с другими панками!
 ghost-role-information-syndie-boss-dungeon-name = Командир Синдиката
 ghost-role-information-syndie-boss-dungeon-description = Вы - Командир отряда Синдиката. Защищайте это место от незваных гостей из NT. Покажите, кто тут БОСС.
+ghost-role-information-curie-name = Кьюри
+ghost-role-information-curie-description = Слизнекот, что может собрать ТЭГ лапками меньше, чем за пять минут.
+ghost-role-information-cult-cat-name = Кот Культа Крови
+ghost-role-information-cult-cat-description = Самое милое и доброжелательное создание Культа Крови... Ведь так?
+ghost-role-information-cult-cat-rules = Вы являетесь [color=yellow][bold]свободным агентом[/bold][/color] и вольны выбирать свой образ жизни самостоятельно.
+                                        Пожалуйста, обратите внимание, что [color=yellow]все правила сервера по-прежнему применяются к вам.[/color] Кроме того:
+                                        - [color=red]НЕ НАНОСИТЕ[/color] урон шаттлам игроков или их содержимому.
 ghost-role-information-dungeon-boss-rules = Вы — [color=red][bold]командный антагонист[/bold][/color] для всех монстров этой экспедиции.
                                         Сражайтесь с игроками в комплексе, защищая свой комплекс.
                                         Обратите внимание, что [color=yellow]все правила сервера по-прежнему применяются к вам.[/color] Кроме того:

--- a/Resources/Prototypes/_NF/Roles/Ghostroles/whitelisted.yml
+++ b/Resources/Prototypes/_NF/Roles/Ghostroles/whitelisted.yml
@@ -46,7 +46,7 @@
   description: ghost-role-information-curie-description
   rules: ghost-role-information-emotional-support-rules
   entityPrototype: MobCatCurie
-  whitelisted: true
+  whitelisted: false
 
 - type: ghostRole
   id: CatMistake


### PR DESCRIPTION
Гост-роли котиков получили свой кусочек русификации. Кьюри больше не закрыт на ВЛ.

## О пулл-реквесте
- Призрачная роль кота Curie с электростанции Эдисона теперь не закрыта на ВЛ.
- Кот Культа Крови (BloodCultCat) и Curie получили перевод названия и описания в меню выбора ролей призраков.

## Как протестировать
- Открыть меню ролей призраков / заспавнить роли, указанные выше.

## Требования
<!-- Подтвердите следующее, поставив X в квадратных скобках [X]: -->
- [х] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [х] Я приложил медиа-материалы к этому PR или они не требуются.
- [х] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [х] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.
<!-- Имейте в виду, что несоблюдение этих требований может привести к закрытию PR по усмотрению мейнтейнера -->

## Критические изменения
___

**Журнал изменений**

:cl:
- tweak: Перевод имени и описания кота Культа Крови.
- tweak: Перевод имени и описания кота с электростанции Эдисона.
- fix: Удален вайтлист на роль кота с электростанции Эдисона (по запросу из https://github.com/Lua-Frontier/sector-frontier-14/issues/194)
