### PR TITLE
Venture-minorupdate

### DIFF
--- a/Resources/Maps/_Lua/Shuttles/Expedition/Concord-Venture.yml
+++ b/Resources/Maps/_Lua/Shuttles/Expedition/Concord-Venture.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 11/07/2025 14:19:12
-  entityCount: 460
+  time: 11/07/2025 14:26:05
+  entityCount: 462
 maps: []
 grids:
 - 1
@@ -41,7 +41,7 @@ entities:
     - type: MetaData
       name: Concord-Venture
     - type: Transform
-      pos: 35.41399,-0.09908295
+      pos: 35.321743,-0.09908295
       parent: invalid
     - type: MapGrid
       chunks:
@@ -547,6 +547,18 @@ entities:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
+    - type: DeviceList
+      devices:
+      - 239
+      - 247
+      - 248
+      - 243
+      - 241
+      - 246
+      - 245
+      - 240
+      - 163
+      - 79
 - proto: AirCanister
   entities:
   - uid: 3
@@ -2047,6 +2059,9 @@ entities:
     - type: Transform
       pos: 11.5,7.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 239
@@ -2055,6 +2070,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 240
@@ -2062,6 +2080,9 @@ entities:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 241
@@ -2070,6 +2091,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,10.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 243
@@ -2078,6 +2102,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeColor
       color: '#0335FCFF'
 - proto: GasVentScrubber
@@ -2087,6 +2114,9 @@ entities:
     - type: Transform
       pos: 10.5,7.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
@@ -2097,6 +2127,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,7.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
@@ -2107,6 +2140,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
@@ -2117,6 +2153,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,5.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
@@ -2127,6 +2166,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
@@ -2529,6 +2571,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,4.5
       parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
 - proto: PoweredlightBlue
   entities:
   - uid: 312
@@ -2573,6 +2620,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,7.5
+      parent: 1
+- proto: ShelfRWood
+  entities:
+  - uid: 462
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,4.5
       parent: 1
 - proto: ShelfWallFreezerWhite
   entities:


### PR DESCRIPTION
## О пулл-реквесте
Добавил мерк фаб, т.к это обязательный атрибут на экспедиционных кораблях. А также чуток переделал дормы.

## Обоснование/Баланс

Раньше его не было, потому что игроки могли его купить сами, но сейчас оффы вырезали его, а корабль то экспедиционный

## Как протестировать
купить/заспавнить

## Медиа
<img width="1731" height="993" alt="image" src="https://github.com/user-attachments/assets/89827b5c-75d6-4334-a990-0a0465f53d0e" />
<img width="1717" height="1130" alt="image" src="https://github.com/user-attachments/assets/93f4c316-516f-482b-b526-bb25f67fd2b2" />


## Требования
- [x] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я приложил медиа-материалы к этому PR или они не требуются.
- [x] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [x] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.

**Журнал изменений**

:cl:
- tweak: Concord-Venture: Добавлен ТехФаб наёмников.