### PR TITLE
Горные пульсеры народу!

### DIFF
--- a/Resources/Prototypes/_Lua/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_Lua/Entities/Objects/Devices/flatpacks.yml
@@ -57,3 +57,18 @@
     entity: WeaponShuttleGrapplingTurret
   - type: StaticPrice
     price: 150
+
+- type: entity
+  parent: BaseNFFlatpack
+  id: WeaponTurretM25FlatPack
+  name: упакованный M25 горный импульсер
+  description: Использует механизмы для запуска... чего-то. Легко разрушает породу.
+  components:
+  - type: Flatpack
+    entity: WeaponTurretM25
+  - type: StaticPrice
+    price: 640
+  - type: Sprite
+    sprite: _Lua/Flatpack/flatpack.rsi
+    layers:
+    - state: ship_weapon

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -217,7 +217,7 @@
 - type: entity
   id: WeaponTurretM25
   name: M25 mining pulser
-  parent: BallisticArtilleryUnanchorable #Lua BallisticArtillery<BallisticArtilleryUnanchorable
+  parent: BallisticArtillery
   description: Uses mechanisms to launch... something. Destroys rock easily.
   components:
   - type: StaticPrice

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -15,6 +15,7 @@
     MaterialReclaimerFlatpack: 4294967295 # Infinite
     ScrapProcessorFlatpack: 4294967295 # Infinite
     ShuttleGunKineticFlatpack: 4294967295 # Infinite
+    WeaponTurretM25FlatPack: 4294967295 # Infinite
     # Service
     #ServiceTechFabFlatpack: 4294967295 # Infinite
     CutterMachineFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -15,7 +15,7 @@
     MaterialReclaimerFlatpack: 4294967295 # Infinite
     ScrapProcessorFlatpack: 4294967295 # Infinite
     ShuttleGunKineticFlatpack: 4294967295 # Infinite
-    WeaponTurretM25FlatPack: 4294967295 # Infinite
+    WeaponTurretM25FlatPack: 4294967295 # Lua
     # Service
     #ServiceTechFabFlatpack: 4294967295 # Infinite
     CutterMachineFlatpack: 4294967295 # Infinite


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/ru/getting-started/pr-guideline -->
<!-- Сообщения со стрелочками это комментарии, их не будет видно -->

## О пулл-реквесте
изменен парент горного импульсера для отката его неоткручиваемости.
Так-же теперь он есть в упакомате за 16000.

## Обоснование / Баланс
Горные импульсеры удобны, но есть всего 1 шаттл с ними и тот ограничен одним на всю смену.... А таким образом любой сможет переукомплектовать свой шаттл в горнодобывающий и копать не буром а корабельными орудиями.


## Как протестировать
Запускаем локальный сервер и видим в упак-о-мате упакованный M25 горный импульсер за 16000

## Требования
<!-- Подтвердите следующее, поставив X в квадратных скобках [X]: -->
- [x] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я приложил медиа-материалы к этому PR или они не требуются.
- [x] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [x] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.

:cl:
- add: Добавлена упаковка M25 горного импульсера в продажу Упак-о-мата за 16 тысяч
- tweak: Теперь М25 откручивается.
