### PR TITLE
Локализация расовых акцентов

### DIFF
--- a/Content.Server/Speech/EntitySystems/LizardAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/LizardAccentSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Content.Shared.Speech;
+using Robust.Shared.Random; // RuLocal
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -11,6 +12,8 @@ public sealed class LizardAccentSystem : EntitySystem
     private static readonly Regex RegexInternalX = new(@"(\w)x");
     private static readonly Regex RegexLowerEndX = new(@"\bx([\-|r|R]|\b)");
     private static readonly Regex RegexUpperEndX = new(@"\bX([\-|r|R]|\b)");
+
+    [Dependency] private readonly IRobustRandom _random = default!; // RuLocal
 
     public override void Initialize()
     {
@@ -33,6 +36,48 @@ public sealed class LizardAccentSystem : EntitySystem
         // eckS
         message = RegexUpperEndX.Replace(message, "ECKS$1");
 
+        // StartRuLocal
+        // ш => шшш
+        message = Regex.Replace(
+            message,"ш{1,3}",
+            _random.Pick(new List<string>() { "шш", "шшш" })
+        );
+        // Ш => ШШШ
+        message = Regex.Replace(
+            message,"Ш{1,3}",
+            _random.Pick(new List<string>() { "ШШ", "ШШШ" })
+        );
+        // ч => щщщ
+        message = Regex.Replace(
+            message,"ч{1,3}",
+            _random.Pick(new List<string>() { "щщ", "щщщ" })
+        );
+        // Ч => ЩЩЩ
+        message = Regex.Replace(
+            message,"Ч{1,3}",
+            _random.Pick(new List<string>() { "ЩЩ", "ЩЩЩ" })
+        );
+        // c => ссс
+        message = Regex.Replace(
+            message,"с{1,3}",
+            _random.Pick(new List<string>() { "сс", "ссс" })
+        );
+        // С => CCC
+        message = Regex.Replace(
+            message,"С{1,3}",
+            _random.Pick(new List<string>() { "СС", "ССС" })
+        );
+        // з => ссс
+        message = Regex.Replace(
+            message,"з{1,3}",
+            _random.Pick(new List<string>() { "сс", "ссс" })
+        );
+        // З => CCC
+        message = Regex.Replace(
+            message,"З{1,3}",
+            _random.Pick(new List<string>() { "СС", "ССС" })
+        );
+        // EndRuLocal
         args.Message = message;
     }
 }

--- a/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Content.Shared.Speech;
+using Robust.Shared.Random; // RuLocal
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -8,6 +9,8 @@ public sealed class MothAccentSystem : EntitySystem
 {
     private static readonly Regex RegexLowerBuzz = new Regex("z{1,3}");
     private static readonly Regex RegexUpperBuzz = new Regex("Z{1,3}");
+
+    [Dependency] private readonly IRobustRandom _random = default!; // RuLocal
 
     public override void Initialize()
     {
@@ -23,6 +26,29 @@ public sealed class MothAccentSystem : EntitySystem
         message = RegexLowerBuzz.Replace(message, "zzz");
         // buZZZ
         message = RegexUpperBuzz.Replace(message, "ZZZ");
+
+        // StartRuLocal
+        // з => ззз
+        message = Regex.Replace(
+            message,"з{1,3}",
+            _random.Pick(new List<string>() { "зз", "ззз" })
+        );
+        // З => ЗЗЗ
+        message = Regex.Replace(
+            message,"З{1,3}",
+            _random.Pick(new List<string>() { "ЗЗ", "ЗЗЗ" })
+        );
+        // ж => жжж
+        message = Regex.Replace(
+            message,"ж{1,3}",
+            _random.Pick(new List<string>() { "жж", "ЖЖ" })
+        );
+        // Ж => ЖЖЖ
+        message = Regex.Replace(
+            message,"Ж{1,3}",
+            _random.Pick(new List<string>() { "ЖЖ", "ЖЖЖ" })
+        );
+        // EndRuLocal
 
         args.Message = message;
     }

--- a/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
@@ -41,7 +41,7 @@ public sealed class MothAccentSystem : EntitySystem
         // ж => жжж
         message = Regex.Replace(
             message,"ж{1,3}",
-            _random.Pick(new List<string>() { "жж", "ЖЖ" })
+            _random.Pick(new List<string>() { "жж", "жжж" })
         );
         // Ж => ЖЖЖ
         message = Regex.Replace(


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/ru/getting-started/pr-guideline -->
<!-- Сообщения со стрелочками это комментарии, их не будет видно -->

## О пулл-реквесте
- Локализовал акценты унатхов и ниан.

У вульп акцента как такогово вообще нет, и не думаю, что нужен. Но можно добавить рычащий (как у плафеймов), если нужно.
Пример акцента унатхов: "Чёрная звезда" - "ЩЩЩёрная ссвесссда"
Пример акцента ниан: "Заражение" - "ЗЗаражжжение"
<!-- Что вы изменили? -->
<!-- Если это изменение кода, кратко опишите как работает ваш новый код. Это упростит проверку. -->

## Технические детали
Все изменения в системах помечены комментарием //RuLocal
<!-- Краткое описание изменений в коде для удобства проверки. -->

## Требования
<!-- Подтвердите следующее, поставив X в квадратных скобках [X]: -->
- [X] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я приложил медиа-материалы к этому PR или они не требуются.
- [X] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [X] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.
<!-- Имейте в виду, что несоблюдение этих требований может привести к закрытию PR по усмотрению мейнтейнера -->

**Журнал изменений**
<!-- Добавьте запись в журнал изменений, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на геймплей.
Убедитесь, что прочитали руководство и удалите этот шаблон из комментария, чтобы он отобразился.
Запись должна содержать символ :cl:, чтобы бот распознал изменения и добавил их в игровой журнал изменений. -->

:cl: Nz
- fix: Нианы и унатхи теперь имеют свои акценты.
