### PR TITLE
Исправление бага с чернеющим экраном.

### DIFF
--- a/Content.Shared/Camera/SharedCameraRecoilSystem.cs
+++ b/Content.Shared/Camera/SharedCameraRecoilSystem.cs
@@ -40,6 +40,12 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
 
     private void OnCameraRecoilGetEyeOffset(Entity<CameraRecoilComponent> ent, ref GetEyeOffsetEvent args)
     {
+         // NaN fixes. The check allows you to avoid a fatal client error when shooting at an object from zero distance.
+         if (!float.IsFinite(ent.Comp.CurrentKick.X) || !float.IsFinite(ent.Comp.CurrentKick.Y))
+         {
+             ent.Comp.CurrentKick = Vector2.Zero;
+         }
+    
         args.Offset += ent.Comp.BaseOffset + ent.Comp.CurrentKick;
     }
 


### PR DESCRIPTION

## О пулл-реквесте
Добавлена проверка на неприменимые числа при подсчёте отдачи. Без неё случается баг с затемнением экрана у игроков с включённой тряской экрана.

## Обоснование / Баланс
Это багфикс. Неприятный баг должен быть решён.

## Технические детали
Простая проверка на конечность числа, ничего сверхъестественного.

## Как протестировать
Необходимо включить тряску в настройках, после чего взять протокинетический дробовик(он показывает себя наиболее эффективно), либо другое оружие дальнего боя с заметной отдачей. Без данного изменения при выстреле в шкафчике/внутри стен/вплотную к сущности экран темнеет намертво, либо клиент падает из-за ошибки NaN, а с изменением никаких проблем не происходит. 

## Медиа

## Требования
- [] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).        (Ссылки не работают)
- [X] Я приложил медиа-материалы к этому PR или они не требуются.
- [X] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [X] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.

**Журнал изменений**

:cl:
- fix: Исправлен баг с затемнением экрана при использовании оружия дальнего боя.
